### PR TITLE
Fixes the missing import for polar_distance in doa.doa.polar_plt_dirac

### DIFF
--- a/pyroomacoustics/doa/doa.py
+++ b/pyroomacoustics/doa/doa.py
@@ -2,6 +2,8 @@
 # Date: Feb 15, 2016
 from __future__ import division, print_function, absolute_import
 
+from pyroomacoustics.doa.utils import polar_distance
+
 """Direction of Arrival (DoA) estimation."""
 
 import numpy as np

--- a/pyroomacoustics/doa/doa.py
+++ b/pyroomacoustics/doa/doa.py
@@ -2,7 +2,7 @@
 # Date: Feb 15, 2016
 from __future__ import division, print_function, absolute_import
 
-from pyroomacoustics.doa.utils import polar_distance
+from .utils import polar_distance
 
 """Direction of Arrival (DoA) estimation."""
 


### PR DESCRIPTION
This is crucial when you want to use azimuth_ref arguemnt of the doa.doa.polar_plt_dirac function.