### PR TITLE
Less dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,16 +11,23 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- STFT tutorial and demo notebook.
+
+Changed
+~~~~~~~
+
+- Matplotlib is not a hard requirement anymore. When matplotlib is not
+  installed, only a warning is issued on plotting commands
+- Apply `matplotlib.pyplot.tight_layout` in `pyroomacoustics.Room.plot_rir`
+
 Bugfix
 ~~~~~~
 
 - Monaural signals are now properly handled in one-shot stft/istft
 - Corrected check of size of absorption coefficients list in ``Room.from_corners``
-
-Added
-~~~~~
-
-- STFT tutorial and demo notebook.
 
 `0.1.19`_ - 2018-09-24
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,8 +20,11 @@ Changed
 ~~~~~~~
 
 - Matplotlib is not a hard requirement anymore. When matplotlib is not
-  installed, only a warning is issued on plotting commands
-- Apply `matplotlib.pyplot.tight_layout` in `pyroomacoustics.Room.plot_rir`
+  installed, only a warning is issued on plotting commands. This is useful
+  to run pyroomacoustics on headless servers that might not have matplotlib
+  installed
+- Removed dependencies on ``joblib`` and ``requests`` packages
+- Apply ``matplotlib.pyplot.tight_layout`` in ``pyroomacoustics.Room.plot_rir``
 
 Bugfix
 ~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -106,13 +106,47 @@ Quick Install
 
 Install the package with pip::
 
-    $ pip install pyroomacoustics
+    pip install pyroomacoustics
 
-The requirements are::
+A [cookiecutter](https://github.com/fakufaku/cookiecutter-pyroomacoustics-sim)
+is available that generates a working simulation script for a few 2D/3D
+scenarios::
 
-* numpy 
-* scipy 
-* matplotlib
+    # if necessary install cookiecutter
+    pip install cookiecutter
+
+    # create the simulation script
+    cookiecutter gh:fakufaku/cookiecutter-pyroomacoustics-sim
+
+Dependencies
+------------
+
+The minimal dependencies are::
+
+    numpy 
+    scipy>=0.18.0
+    Cython
+
+where ``Cython`` is only needed to benefit from the compiled accelerated simulator.
+The simulator itself has a pure Python counterpart, so that this requirement could
+be ignored, but is much slower.
+
+On top of that, some functionalities of the package depend on extra packages::
+
+    samplerate   # for resampling signals
+    matplotlib   # to create graphs and plots
+    sounddevice  # to play sound samples
+
+This package is mainly developed under Python 3.5. We try as much as possible to keep
+things compatible with Python 2.7 and run tests and builds under both. However, the tests
+code coverage is not 100% and it might happen that we break some things in Python 2.7 from
+time to time. We apologize in advance for that.
+
+Under Linux and Mac OS, the compiled accelerators require a valid compiler to
+be installed, typically this is GCC. When no compiler is present, the package
+will still install but default to the pure Python implementation which is much
+slower. On Windows, we provide pre-compiled Python Wheels for Python 3.5 and
+3.6.
 
 Example
 -------
@@ -188,7 +222,7 @@ License
 
 ::
 
-  Copyright (c) 2014-2017 EPFL-LCAV
+  Copyright (c) 2014-2018 EPFL-LCAV
 
   Permission is hereby granted, free of charge, to any person obtaining a copy of
   this software and associated documentation files (the "Software"), to deal in

--- a/docs/pyroomacoustics.transform.dft.rst
+++ b/docs/pyroomacoustics.transform.dft.rst
@@ -1,7 +1,7 @@
 DFT
 ===
 
-.. automodule:: pyroomacoustics.realtime.dft
+.. automodule:: pyroomacoustics.transform.dft
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/pyroomacoustics.transform.rst
+++ b/docs/pyroomacoustics.transform.rst
@@ -4,7 +4,7 @@ Transforms
 Module contents
 ---------------
 
-.. automodule:: pyroomacoustics.realtime
+.. automodule:: pyroomacoustics.transform
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/pyroomacoustics.transform.stft.rst
+++ b/docs/pyroomacoustics.transform.stft.rst
@@ -1,7 +1,7 @@
 STFT
 ====
 
-.. automodule:: pyroomacoustics.realtime.stft
+.. automodule:: pyroomacoustics.transform.stft
     :members:
     :undoc-members:
     :show-inheritance:

--- a/examples/room_shoebox_2d.py
+++ b/examples/room_shoebox_2d.py
@@ -18,6 +18,7 @@ source = np.array([1, 4.5])
 room = pra.ShoeBox(
     room_dim,
     fs=16000,
+    absorption=0.1,
     max_order=4)
 
 # add mic and good source to room
@@ -33,4 +34,7 @@ room.image_source_model()
 
 # Plot the result up to fourth order images
 room.plot(img_order=4)
+
+plt.figure()
+room.plot_rir()
 plt.show()

--- a/pyroomacoustics/datasets/tests/test_download_uncompress.py
+++ b/pyroomacoustics/datasets/tests/test_download_uncompress.py
@@ -1,0 +1,14 @@
+import shutil
+from pyroomacoustics.datasets.utils import download_uncompress
+
+test_url = 'https://github.com/LCAV/pyroomacoustics/archive/master.tar.gz'
+extracted_name = 'pyroomacoustics-master'
+
+def test_download_uncompress():
+
+    download_uncompress(test_url)
+    shutil.rmtree(extracted_name, ignore_errors=True)
+
+if __name__ == '__main__':
+
+    test_download_uncompress()

--- a/pyroomacoustics/datasets/utils.py
+++ b/pyroomacoustics/datasets/utils.py
@@ -1,5 +1,5 @@
 
-import os, tarfile, bz2, requests
+import os, tarfile, bz2
 
 try:
     from urllib.request import urlopen

--- a/pyroomacoustics/doa/doa.py
+++ b/pyroomacoustics/doa/doa.py
@@ -497,6 +497,9 @@ class DOA(object):
         ax.xaxis.grid(b=True, color=[0.3, 0.3, 0.3], linestyle=':')
         ax.yaxis.grid(b=True, color=[0.3, 0.3, 0.3], linestyle='--')
         ax.set_ylim([0, 1.05 * (base + height)])
+
+        plt.tight_layout()
+
         if save_fig:
             if file_name is None:
                 file_name = 'polar_recon_dirac.pdf'

--- a/pyroomacoustics/doa/doa.py
+++ b/pyroomacoustics/doa/doa.py
@@ -383,6 +383,11 @@ class DOA(object):
             'dirty image' in the case of FRI.
         """
 
+        if not matplotlib_available:
+            import warnings
+            warnings.warn('Matplotlib is required for plotting')
+            return
+
         if self.dim != 2:
             raise ValueError('This function only handles 2D problems.')
 

--- a/pyroomacoustics/doa/grid.py
+++ b/pyroomacoustics/doa/grid.py
@@ -121,7 +121,12 @@ class GridCircle(Grid):
 
     def plot(self, mark_peaks=0):
 
-        import matplotlib.pyplot as plt
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            import warnings
+            warnings.warn('Matplotlib is required for plotting')
+            return
 
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='polar')
@@ -355,10 +360,16 @@ class GridSphere(Grid):
         ''' Plot the points on the sphere with their values '''
 
         from scipy import rand
-        import matplotlib.colors as colors
-        #from mpl_toolkits.mplot3d import Axes3D
-        import mpl_toolkits.mplot3d as a3
-        import matplotlib.pyplot as plt
+
+        try:
+            import matplotlib.colors as colors
+            #from mpl_toolkits.mplot3d import Axes3D
+            import mpl_toolkits.mplot3d as a3
+            import matplotlib.pyplot as plt
+        except ImportError:
+            import warnings
+            warnings.warn('Matplotlib is required for plotting')
+            return
 
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='3d')

--- a/pyroomacoustics/doa/music.py
+++ b/pyroomacoustics/doa/music.py
@@ -75,13 +75,15 @@ class MUSIC(DOA):
 
         # check if matplotlib imported
         if matplotlib_available is False:
-            warnings.warn('Could not import matplotlib.')
+            import warnings
+            warnings.warn('Matplotlib is required for plotting')
             return
 
         # only for 2D
         if self.grid.dim == 3:
             pass
         else:
+            import warnings
             warnings.warn('Only for 2D.')
             return
 

--- a/pyroomacoustics/doa/plotters.py
+++ b/pyroomacoustics/doa/plotters.py
@@ -24,6 +24,13 @@ def polar_plt_dirac(self, azimuth_ref=None, alpha_ref=None, save_fig=False,
         'dirty image' in the case of FRI.
     """
 
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        import warnings
+        warnings.warn('Matplotlib is required for plotting')
+        return
+
     if self.dim != 2:
         raise ValueError('This function only handles 2D problems.')
 
@@ -174,7 +181,9 @@ def sph_plot_diracs_plotly(
         import plotly.graph_objs as go
         import plotly
     except ImportError:
-        raise ValueError('The plotly package is required to use this function')
+        import warnings
+        warnings.warn('The plotly package is required to use this function')
+        return
 
     plotly.offline.init_notebook_mode()
 
@@ -315,7 +324,12 @@ def sph_plot_diracs(
         The colatitudes indexing the dirty_img 2D map
     '''
 
-    import matplotlib.pyplot as plt
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        import warnings
+        warnings.warn('Matplotlib is required for plotting')
+        return
 
     fig = plt.figure(figsize=(6.47, 4), dpi=90)
     ax = fig.add_subplot(111, projection="mollweide")

--- a/pyroomacoustics/experimental/point_cloud.py
+++ b/pyroomacoustics/experimental/point_cloud.py
@@ -12,8 +12,6 @@ from __future__ import division, print_function
 # Provided by LCAV
 import numpy as np
 from scipy import linalg as la
-from mpl_toolkits.mplot3d import Axes3D
-import matplotlib.pyplot as plt
 
 
 class PointCloud:
@@ -327,6 +325,14 @@ class PointCloud:
 
     def plot(self, axes=None, show_labels=True, **kwargs):
 
+        try:
+            from mpl_toolkits.mplot3d import Axes3D
+            import matplotlib.pyplot as plt
+        except ImportError:
+            import warnings
+            warnings.warn('Matplotlib is required for plotting')
+            return
+
         if self.dim == 2:
 
             # Create a figure if needed
@@ -363,6 +369,8 @@ class PointCloud:
 
 
 if __name__ == '__main__':
+
+    import matplotlib.pyplot as plt
 
     # number of markers
     m = 4

--- a/pyroomacoustics/room.py
+++ b/pyroomacoustics/room.py
@@ -631,6 +631,8 @@ class Room(object):
                     else:
                         plt.xlabel('Normalized frequency')
 
+        plt.tight_layout()
+
 
     def add_microphone_array(self, micArray):
         self.mic_array = micArray

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Cython
 numpy
 scipy>=0.18.0
-matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ numpy
 scipy>=0.18.0
 matplotlib
 joblib
-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ Cython
 numpy
 scipy>=0.18.0
 matplotlib
-joblib

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,6 @@ setup_kwargs = dict(
             'Cython',
             'numpy',
             'scipy>=0.18.0',
-            'matplotlib',
-            'joblib',
             ],
 
         test_suite='nose.collector',


### PR DESCRIPTION
It is desirable to reduce the number of dependencies to a minimum.

This pull requests consistently limits the calls to `matplotlib` to the functions where necessary. When matplotlib is not installed, the function will issue a warning and return without causing an error. 

This is particularly helpful on headless servers where imports of matplotlib would sometimes cause problems when no display is available, or matplotlib is simply not installed.

In addition, the dependencies on `joblib` and `requests` where found to be not necessary and the code was edited to remove them completely.

Finally, small bugs in the doc were corrected and a few `plt.tight_layout` added where necessary. The README was also edited to reflect this.

This PR fixes issue #19 