### PR TITLE
Corrects invalid memory access in build_rir cython code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Bugfix
 ~~~~~~
 
 - Corrects a bug in the update of the demixing matrix in ``pyroomacoustics.bss.auxiva``
+- Corrects invalid memory access in the ``pyroomacoustics.build_rir`` cython accelerator
+  and adds a unit test that checks the cython code output is correct
 
 `0.1.20`_ - 2018-10-04
 ----------------------

--- a/pyroomacoustics/build_rir.pyx
+++ b/pyroomacoustics/build_rir.pyx
@@ -37,7 +37,7 @@ def fast_rir_builder(
     fdl: int
         The length of the fractional delay filter (should be odd)
     lut_gran: int
-        The number of point per unit in the since interpolation table
+        The number of point per unit in the sinc interpolation table
     '''
 
     fdl2 = (fdl - 1) // 2
@@ -45,6 +45,13 @@ def fast_rir_builder(
 
     assert time.shape[0] == visibility.shape[0]
     assert time.shape[0] == alpha.shape[0]
+    assert fdl % 2 == 1
+
+    # check the size of the return array
+    max_sample = ceil(fs * np.max(time)) + fdl2
+    min_sample = floor(fs * np.min(time)) - fdl2
+    assert min_sample >= 0
+    assert max_sample < rir.shape[0]
 
     # create a look-up table of the sinc function and
     # then use linear interpolation

--- a/pyroomacoustics/build_rir.pyx
+++ b/pyroomacoustics/build_rir.pyx
@@ -3,6 +3,8 @@
 import numpy as np
 cimport cython
 
+from libc.math cimport floor, ceil
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def fast_rir_builder(
@@ -41,9 +43,13 @@ def fast_rir_builder(
     fdl2 = (fdl - 1) // 2
     n_times = time.shape[0]
 
-    # create a look-up table of the since function and
+    assert time.shape[0] == visibility.shape[0]
+    assert time.shape[0] == alpha.shape[0]
+
+    # create a look-up table of the sinc function and
     # then use linear interpolation
-    lut_size = (2*fdl2 + 2) * lut_gran + 1
+    cdef float delta = 1. / lut_gran
+    cdef int lut_size = (fdl + 1) * lut_gran + 1
     n = np.linspace(-fdl2-1, fdl2 + 1, lut_size)
 
     cdef double [:] sinc_lut = np.sinc(n)
@@ -55,17 +61,17 @@ def fast_rir_builder(
         if visibility[i] == 1:
             # decompose integer and fractional delay
             sample_frac = fs * time[i]
-            time_ip = int(sample_frac)
+            time_ip = int(floor(sample_frac))
             time_fp = sample_frac - time_ip
 
             # do the linear interpolation
             x_off_frac = (1. - time_fp) * lut_gran
-            lut_gran_off = int(x_off_frac)
-            x_off = x_off_frac - lut_gran_off
+            lut_gran_off = int(floor(x_off_frac))
+            x_off = (x_off_frac - lut_gran_off)
             lut_pos = lut_gran_off
             k = 0
             for f in range(-fdl2, fdl2+1):
-                rir[time_ip + f] += alpha[i] * hann[k] * (sinc_lut[lut_pos-1] 
-                        + x_off * (sinc_lut[lut_pos] - sinc_lut[lut_pos-1]))
+                rir[time_ip + f] += alpha[i] * hann[k] * (sinc_lut[lut_pos] 
+                        + x_off * (sinc_lut[lut_pos+1] - sinc_lut[lut_pos]))
                 lut_pos += lut_gran
                 k += 1

--- a/pyroomacoustics/tests/test_build_rir.py
+++ b/pyroomacoustics/tests/test_build_rir.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import pyroomacoustics as pra
 import numpy as np
 

--- a/pyroomacoustics/tests/test_build_rir.py
+++ b/pyroomacoustics/tests/test_build_rir.py
@@ -1,0 +1,91 @@
+import pyroomacoustics as pra
+import numpy as np
+
+# tolerance for test success (1%)
+tol = 0.01
+
+fdl = 81
+fs = 16000
+
+t0 = (2 * fdl + 0.1) / fs
+t1 = (3 * fdl - 0.1) / fs
+t2 = (4 * fdl + 0.45) / fs
+t3 = (5 * fdl + 0.001) / fs
+t4 = (6 * fdl + 0.999) / fs
+
+times = np.array(
+        [
+            [ t0 , t1 + (1 / 40 / 16000), t2, ],
+            [ t0, t1 + (10 / fs), 3 * t3, ],
+            [ t0, t3, t4, ],
+            ],
+        )
+alphas = np.array(
+        [
+            [ 1., 0.5, -0.1 ],
+            [ 0.5, 0.3, 0.1 ],
+            [ 0.3, 2., 0.1 ],
+            ],
+        )
+visibilities = np.array(
+        [
+            [ 1, 1, 1,],
+            [ 1, 1, 1,],
+            [ 0, 1, 1,],
+            ],
+        dtype=np.int32,
+        )
+
+
+def build_rir(time, alpha, visibility, fs, fdl):
+
+    # fractional delay length
+    fdl = pra.constants.get('frac_delay_length')
+    fdl2 = (fdl-1) // 2
+
+    # the number of samples needed
+    N = int(np.ceil(time.max() * fs) + fdl)
+
+    ir_ref = np.zeros(N)
+    ir_cython = np.zeros(N)
+
+    try:
+        from pyroomacoustics import build_rir
+        # Try to use the Cython extension
+        build_rir.fast_rir_builder(ir_cython, time, alpha, visibility, fs, fdl)
+
+    except ImportError:
+        return 0., 0.
+
+    # fallback to pure Python implemenation
+    for i in range(time.shape[0]):
+        if visibility[i] == 1:
+            time_ip = int(np.round(fs * time[i]))
+            time_fp = (fs * time[i]) - time_ip
+            ir_ref[time_ip-fdl2:time_ip+fdl2+1] += alpha[i] * pra.fractional_delay(time_fp)
+
+    return ir_ref, ir_cython
+
+def test_build_rir():
+
+    for t, a, v in zip(times, alphas, visibilities):
+        ir_ref, ir_cython = build_rir(times[0], alphas[0], visibilities[0], fs, fdl)
+        assert np.max(np.abs(ir_ref - ir_cython)) < tol
+    
+
+if __name__ == '__main__':
+
+    import matplotlib.pyplot as plt
+
+    for t, a, v in zip(times, alphas, visibilities):
+        ir_ref, ir_cython = build_rir(times[0], alphas[0], visibilities[0], fs, fdl)
+
+        print('Error:', np.max(np.abs(ir_ref - ir_cython)))
+
+        plt.figure()
+        plt.plot(ir_ref, label='ref')
+        plt.plot(ir_cython, label='cython')
+        plt.legend()
+
+    plt.show()
+

--- a/pyroomacoustics/tests/test_build_rir.py
+++ b/pyroomacoustics/tests/test_build_rir.py
@@ -1,6 +1,13 @@
 import pyroomacoustics as pra
 import numpy as np
 
+try:
+    from pyroomacoustics import build_rir
+    build_rir_available = True
+except:
+    print('build_rir not available')
+    build_rir_available = False
+
 # tolerance for test success (1%)
 tol = 0.01
 
@@ -36,8 +43,13 @@ visibilities = np.array(
         dtype=np.int32,
         )
 
+time_short = np.array([0.])
+time_long = np.array([0.1])
+alpha_dummy = np.array([1.])
+visibility_dummy = np.array([1], dtype=np.int32)
 
-def build_rir(time, alpha, visibility, fs, fdl):
+
+def build_rir_wrap(time, alpha, visibility, fs, fdl):
 
     # fractional delay length
     fdl = pra.constants.get('frac_delay_length')
@@ -49,13 +61,8 @@ def build_rir(time, alpha, visibility, fs, fdl):
     ir_ref = np.zeros(N)
     ir_cython = np.zeros(N)
 
-    try:
-        from pyroomacoustics import build_rir
-        # Try to use the Cython extension
-        build_rir.fast_rir_builder(ir_cython, time, alpha, visibility, fs, fdl)
-
-    except ImportError:
-        return 0., 0.
+    # Try to use the Cython extension
+    build_rir.fast_rir_builder(ir_cython, time, alpha, visibility, fs, fdl)
 
     # fallback to pure Python implemenation
     for i in range(time.shape[0]):
@@ -68,17 +75,100 @@ def build_rir(time, alpha, visibility, fs, fdl):
 
 def test_build_rir():
 
+    if not build_rir_available:
+        return
+
     for t, a, v in zip(times, alphas, visibilities):
-        ir_ref, ir_cython = build_rir(times[0], alphas[0], visibilities[0], fs, fdl)
+        ir_ref, ir_cython = build_rir_wrap(times[0], alphas[0], visibilities[0], fs, fdl)
         assert np.max(np.abs(ir_ref - ir_cython)) < tol
-    
+
+def test_short():
+    ''' Tests that an error is raised if a provided time goes below the zero index '''
+
+    if not build_rir_available:
+        return
+
+    N = 100
+    fs = 16000
+    fdl = 81
+    rir = np.zeros(N)
+
+    time = np.array([0.])
+    alpha = np.array([1.])
+    visibility = np.array([1], dtype=np.int32)
+
+    try:
+        build_rir.fast_rir_builder(rir, time, alpha, visibility, fs, fdl)
+        assert False
+    except AssertionError:
+        print('Ok, short times are caught')
+
+
+
+def test_long():
+    ''' Tests that an error is raised if a time falls outside the rir array '''
+
+    if not build_rir_available:
+        return
+
+    N = 100
+    fs = 16000
+    fdl = 81
+    rir = np.zeros(N)
+
+    time = np.array([(N-1) / fs])
+    alpha = np.array([1.])
+    visibility = np.array([1], dtype=np.int32)
+
+    try:
+        build_rir.fast_rir_builder(rir, time, alpha, visibility, fs, fdl)
+        assert False
+    except AssertionError:
+        print('Ok, long times are caught')
+
+def test_errors():
+    ''' Tests that errors are raised when array lengths differ '''
+
+    if not build_rir_available:
+        return
+
+    N = 300
+    fs = 16000
+    fdl = 81
+    rir = np.zeros(N)
+
+    time = np.array([100 / fs, 200 / fs])
+    alpha = np.array([1., 1.])
+    visibility = np.array([1, 1], dtype=np.int32)
+
+    try:
+        build_rir.fast_rir_builder(rir, time, alpha[:1], visibility, fs, fdl)
+        assert False
+    except:
+        print('Ok, alpha error occured')
+        pass
+
+    try:
+        build_rir.fast_rir_builder(rir, time, alpha, visibility[:1], fs, fdl)
+        assert False
+    except:
+        print('Ok, visibility error occured')
+        pass
+
+    try:
+        build_rir.fast_rir_builder(rir, time, alpha, visibility, fs, 80)
+        assert False
+    except:
+        print('Ok, fdl error occured')
+        pass
+
 
 if __name__ == '__main__':
 
     import matplotlib.pyplot as plt
 
     for t, a, v in zip(times, alphas, visibilities):
-        ir_ref, ir_cython = build_rir(times[0], alphas[0], visibilities[0], fs, fdl)
+        ir_ref, ir_cython = build_rir_wrap(times[0], alphas[0], visibilities[0], fs, fdl)
 
         print('Error:', np.max(np.abs(ir_ref - ir_cython)))
 
@@ -86,6 +176,10 @@ if __name__ == '__main__':
         plt.plot(ir_ref, label='ref')
         plt.plot(ir_cython, label='cython')
         plt.legend()
+
+    test_short()
+    test_long()
+    test_errors()
 
     plt.show()
 


### PR DESCRIPTION
Corrects invalid memory access in the ``pyroomacoustics.build_rir`` cython accelerator and adds a unit test that checks the cython code output is correct.

- [ ] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Comments:
* I'm not sure how to add docstring to cython extension code
* The doc stays unchanged