### PR TITLE
Add Logo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,9 @@
-Pyroomacoustics
-===============
-
 .. image:: https://github.com/LCAV/pyroomacoustics/raw/master/logo/pyroomacoustics_logo_horizontal.png
    :scale: 80 %
    :alt: Pyroomacoustics logo
    :align: left
+
+------------------------------------------------------------------------------
 
 .. image:: https://travis-ci.org/LCAV/pyroomacoustics.svg?branch=pypi-release
     :target: https://travis-ci.org/LCAV/pyroomacoustics

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 Pyroomacoustics
 ===============
 
+.. image:: https://github.com/LCAV/pyroomacoustics/raw/master/logo/pyroomacoustics_logo_horizontal.png
+   :scale: 80 %
+   :alt: Pyroomacoustics logo
+   :align: left
+
 .. image:: https://travis-ci.org/LCAV/pyroomacoustics.svg?branch=pypi-release
     :target: https://travis-ci.org/LCAV/pyroomacoustics
 .. image:: https://readthedocs.org/projects/pyroomacoustics/badge/?version=pypi-release


### PR DESCRIPTION
This PR adds a logo in the `logo` folder and also puts it at the top of the README.