### PR TITLE
Fix error when setting temperature without humidity in ShoeBox constructor

### DIFF
--- a/pyroomacoustics/parameters.py
+++ b/pyroomacoustics/parameters.py
@@ -143,19 +143,22 @@ class Physics(object):
     temperature: float, optional
         The room temperature
     humidity: float in range (0, 100), optional
-        The room relative humidity in %
+        The room relative humidity in %. Default is 0.
     """
 
-    def __init__(self, temperature=None, humidity=0.0):
+    def __init__(self, temperature=None, humidity=None):
 
         self.p = 100.0  # pressure in kilo-Pascal (kPa), not used
-        self.H = humidity
+        if humidity is None:
+            self.H = 0.0
+        else:
+            self.H = humidity
 
         if self.H < 0.0 or self.H > 100:
             raise ValueError("Relative humidity is a value between 0 and 100.")
 
         if temperature is None:
-            temperature = _calculate_temperature(constants.get("c"), self.H)
+            self.T = _calculate_temperature(constants.get("c"), self.H)
         else:
             self.T = temperature
 

--- a/pyroomacoustics/tests/test_shoebox_constants.py
+++ b/pyroomacoustics/tests/test_shoebox_constants.py
@@ -1,0 +1,19 @@
+import pyroomacoustics as pra
+from pyroomacoustics.parameters import _calculate_temperature
+
+
+def test_set_temperature_wo_humidity():
+    room = pra.ShoeBox(p=[3, 3, 3], temperature=21)
+    assert room.physics.H == 0.0
+
+
+def test_set_humidity_wo_temperature():
+    room = pra.ShoeBox(p=[3, 3, 3], humidity=21)
+    assert room.physics.T == _calculate_temperature(
+        room.physics.get_sound_speed(), room.physics.H
+    )
+
+
+if __name__ == '__main__':
+    test_set_temperature_wo_humidity()
+    test_set_humidity_wo_temperature()


### PR DESCRIPTION
`humidity` would be set to `None` from the `ShoeBox` constructor so the following statement would fail when the `Physics` constructor was called (due to setting the `temperature`).

```python
if self.H < 0.0 or self.H > 100:
```

---

Thanks for sending a pull request (PR), we really appreciate that! Before hitting the submit button, we'd be really glad if you could make sure all the following points have been cleared.

Please also refer to the doc on [contributing](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html) for more details. Even if you can't check all the boxes below, do not hesitate to go ahead with the PR and ask for help there.

- [ ] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [ ] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [x] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [ ] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
