### PR TITLE
Adds a pyproject.toml file for pip and friends

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Bugfix
 ~~~~~~
 
 - From Issue #150, increase max iterations to check if point is inside room
+- Issues #117 #163, adds project file `pyproject.toml` so that pip can know which dependencies are necessary for setup
 
 Added
 ~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel", 'numpy', 'Cython']  # PEP 508 specifications.


### PR DESCRIPTION
This is a fix for issues #117 #163 

The `pyproject.toml` file follows PEP 518 and lets package manager know about the dependencies necessary to run the `setup.py` install script.