### PR TITLE
Remove numpy import from setup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.idea
+.env
+.github
+venv*
+*egg-info
+.cache
+docs/
+logo/
+build/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Bugfix
 
 - Issue #162 (crash with max_order>31 on windows), seems fixed by the new C++ simulator
 - Test for issue #162 added
+- Fix Binder link
+
+Added
+~~~~~~~
+
+- Minimal `Dockerfile` example.
 
 `0.4.0`_ - 2020-06-03
 ---------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# NB: You will have to increase the memory of your Docker containers to 4 GB.
+# Less may also be sufficient, but this is necessary for building the C++ code
+# for pyroomacoustics. How to increase memory: https://docs.docker.com/docker-for-mac/#resources
+#
+# Then you can build with: `docker build -t pyroom_container .`
+# And enter container with: `docker run -it pyroom_container:latest /bin/bash`
+FROM ubuntu:18.04
+RUN dpkg --add-architecture i386
+RUN apt-get update
+RUN apt-get install -y python3-dev python3-pip
+RUN apt-get install -y libeigen3-dev
+RUN pip3 install numpy Cython scipy pybind11
+RUN pip3 install pyroomacoustics==0.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,5 @@ FROM ubuntu:18.04
 RUN dpkg --add-architecture i386
 RUN apt-get update
 RUN apt-get install -y python3-dev python3-pip
-RUN apt-get install -y libeigen3-dev
-RUN pip3 install numpy Cython scipy pybind11
+RUN pip3 install numpy pybind11
 RUN pip3 install pyroomacoustics==0.4.0

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@
     :target: http://pyroomacoustics.readthedocs.io/en/pypi-release/
     :alt: Documentation Status
 .. image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/LCAV/pyroomacoustics/next_gen_simulator?filepath=notebooks%2Fpyroomacoustics_demo.ipynb
+    :target: https://mybinder.org/v2/gh/LCAV/pyroomacoustics/master?filepath=notebooks%2Fpyroomacoustics_demo.ipynb
     :alt: Test on mybinder
 
 Summary
@@ -27,7 +27,7 @@ can be divided into three main components:
 
 Together, these components form a package with the potential to speed up the time to market
 of new algorithms by significantly reducing the implementation overhead in the
-performance evaluation step. Please refer to `this notebook <https://mybinder.org/v2/gh/LCAV/pyroomacoustics/next_gen_simulator?filepath=notebooks%2Fpyroomacoustics_demo.ipynb>`_
+performance evaluation step. Please refer to `this notebook <https://mybinder.org/v2/gh/LCAV/pyroomacoustics/master?filepath=notebooks%2Fpyroomacoustics_demo.ipynb>`_
 for a demonstration of the different components of this package.
 
 Room Acoustics Simulation

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,20 @@ scenarios::
     # run the newly created script
     python <chosen_script_name>.py
 
+
+We have also provided a minimal `Dockerfile` example in order to install and
+run the package within a Docker container. Note that you should [increase the
+memory](https://docs.docker.com/docker-for-mac/#resources) of your containers
+to 4 GB. Less may also be sufficient, but this is necessary for building the
+C++ code extension. You can build the container with::
+
+    docker build -t pyroom_container .
+
+And enter the container with::
+
+    docker run -it pyroom_container:latest /bin/bash
+
+
 Dependencies
 ------------
 
@@ -138,6 +152,7 @@ The minimal dependencies are::
     numpy 
     scipy>=0.18.0
     Cython
+    pybind11
 
 where ``Cython`` is only needed to benefit from the compiled accelerated simulator.
 The simulator itself has a pure Python counterpart, so that this requirement could

--- a/README.rst
+++ b/README.rst
@@ -132,10 +132,9 @@ scenarios::
 
 
 We have also provided a minimal `Dockerfile` example in order to install and
-run the package within a Docker container. Note that you should [increase the
-memory](https://docs.docker.com/docker-for-mac/#resources) of your containers
-to 4 GB. Less may also be sufficient, but this is necessary for building the
-C++ code extension. You can build the container with::
+run the package within a Docker container. Note that you should `increase the memory <https://docs.docker.com/docker-for-mac/#resources>`_
+of your containers to 4 GB. Less may also be sufficient, but this is necessary
+for building the C++ code extension. You can build the container with::
 
     docker build -t pyroom_container .
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ import sys
 from codecs import open
 from os import path
 
-import numpy
-
 # import version from file
 with open("pyroomacoustics/version.py") as f:
     exec(f.read())


### PR DESCRIPTION
Thanks for sending a pull request (PR), we really appreciate that! Before hitting the submit button, we'd be really glad if you could make sure all the following points have been cleared.

Please also refer to the doc on [contributing](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html) for more details. Even if you can't check all the boxes below, do not hesitate to go ahead with the PR and ask for help there.

- [ ] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [ ] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [ ] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [ ] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:

---

Hey @fakufaku I think we don't need `numpy` anymore in the setup file. I don't see it being used anywhere.

I've also added a minimal `Dockerfile` example.
