### PR TITLE
Changes geometry eps to 1e-5 / specialized is_inside for shoebox rooms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Bugfix
 ~~~~~~
 
 - Fixes the Dockerfile so that we don't have to install the build dependencies manually
+- Change the eps for geometry computations from 1e-4 to 1e-5 in ``libroom``
+
+Added
+~~~~~
+
+- A specialized ``is_inside`` routine for ``ShoeBox`` rooms
 
 `0.4.1`_ - 2020-07-02
 ---------------------
@@ -28,7 +34,7 @@ Bugfix
 - Adds the pyproject.toml file in MANIFEST.in so that it gets picked up for packaging
 
 Added
-~~~~~~~
+~~~~~
 
 - Minimal `Dockerfile` example.
 

--- a/pyroomacoustics/libroom_src/libroom.cpp
+++ b/pyroomacoustics/libroom_src/libroom.cpp
@@ -39,7 +39,7 @@
 
 namespace py = pybind11;
 
-float libroom_eps = 1e-4;  // epsilon is set to 0.1 millimeter (100 um)
+float libroom_eps = 1e-5;  // epsilon is set to 0.1 millimeter (100 um)
 
 
 PYBIND11_MODULE(libroom, m) {

--- a/pyroomacoustics/room.py
+++ b/pyroomacoustics/room.py
@@ -970,7 +970,7 @@ class Room(object):
         sources=None,
         mics=None,
         materials=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Creates a 2D room by giving an array of corners.
@@ -1085,7 +1085,7 @@ class Room(object):
             sigma2_awgn=sigma2_awgn,
             sources=sources,
             mics=mics,
-            **kwargs
+            **kwargs,
         )
 
     def extrude(
@@ -1247,7 +1247,7 @@ class Room(object):
         figsize=None,
         no_axis=False,
         mic_marker_size=10,
-        **kwargs
+        **kwargs,
     ):
         """ Plots the room with its walls, microphones, sources and images """
 
@@ -2155,6 +2155,8 @@ class Room(object):
                 else:
                     return False
 
+        return False
+
         # We should never reach this
         raise ValueError(
             """
@@ -2521,11 +2523,26 @@ class ShoeBox(Room):
         self.shoebox_dim = np.append(self.shoebox_dim, height)
 
     def get_volume(self):
-
         """
         Computes the volume of a room
-        :param room: the room object
-        :return: the volume in cubic unit
+
+        Returns
+        -------
+        the volume in cubic unit
         """
 
         return np.prod(self.shoebox_dim)
+
+    def is_inside(self, pos):
+        """
+        Parameters
+        ----------
+        pos: array_like
+            The position to test in an array of size 2 for a 2D room and 3 for a 3D room
+
+        Returns
+        -------
+        True if ``pos`` is a point in the room, ``False`` otherwise.
+        """
+        pos = np.array(pos)
+        return np.all(pos) >= 0 and np.all(pos <= self.shoebox_dim)

--- a/pyroomacoustics/room.py
+++ b/pyroomacoustics/room.py
@@ -970,7 +970,7 @@ class Room(object):
         sources=None,
         mics=None,
         materials=None,
-        **kwargs,
+        **kwargs
     ):
         """
         Creates a 2D room by giving an array of corners.
@@ -1085,7 +1085,7 @@ class Room(object):
             sigma2_awgn=sigma2_awgn,
             sources=sources,
             mics=mics,
-            **kwargs,
+            **kwargs
         )
 
     def extrude(
@@ -1247,7 +1247,7 @@ class Room(object):
         figsize=None,
         no_axis=False,
         mic_marker_size=10,
-        **kwargs,
+        **kwargs
     ):
         """ Plots the room with its walls, microphones, sources and images """
 


### PR DESCRIPTION
This is a fix for issue #181 

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
