### PR TITLE
Normalization of Fractional Delay Filter

### DIFF
--- a/pyroomacoustics/build_rir.pyx
+++ b/pyroomacoustics/build_rir.pyx
@@ -64,7 +64,7 @@ def fast_rir_builder(
     cdef int lut_pos, i, f, time_ip
     cdef float x_off, x_off_frac, sample_frac
 
-    for i in range(n_times):
+       for i in range(n_times):
         if visibility[i] == 1:
             # decompose integer and fractional delay
             sample_frac = fs * time[i]
@@ -77,8 +77,21 @@ def fast_rir_builder(
             x_off = (x_off_frac - lut_gran_off)
             lut_pos = lut_gran_off
             k = 0
-            for f in range(-fdl2, fdl2+1):
-                rir[time_ip + f] += alpha[i] * hann[k] * (sinc_lut[lut_pos] 
+            for k in range(2*fdl2+1):
+                rir_tmp[k] = hann[k] * (sinc_lut[lut_pos]
                         + x_off * (sinc_lut[lut_pos+1] - sinc_lut[lut_pos]))
                 lut_pos += lut_gran
-                k += 1
+
+
+            max_tmp = 0
+            for f in range(2*fdl2+1):
+                if rir_tmp[f] > max_tmp:
+                    max_tmp = rir_tmp[f]
+
+            for f in range(2*fdl2+1):
+                rir_tmp[f] = alpha[i]*rir_tmp[f]/max_tmp
+
+            k = 0
+            for f in range(-fdl2, fdl2+1):
+                rir[time_ip + f] += rir_tmp[k]
+                k+=1

--- a/pyroomacoustics/build_rir.pyx
+++ b/pyroomacoustics/build_rir.pyx
@@ -63,6 +63,8 @@ def fast_rir_builder(
     cdef double [:] hann = np.hanning(fdl)
     cdef int lut_pos, i, f, time_ip
     cdef float x_off, x_off_frac, sample_frac
+    cdef double max_tmp
+    cdef double [:] rir_tmp = np.zeros(2*fdl2+1)
 
     for i in range(n_times):
         if visibility[i] == 1:

--- a/pyroomacoustics/build_rir.pyx
+++ b/pyroomacoustics/build_rir.pyx
@@ -64,7 +64,7 @@ def fast_rir_builder(
     cdef int lut_pos, i, f, time_ip
     cdef float x_off, x_off_frac, sample_frac
 
-       for i in range(n_times):
+    for i in range(n_times):
         if visibility[i] == 1:
             # decompose integer and fractional delay
             sample_frac = fs * time[i]

--- a/pyroomacoustics/utilities.py
+++ b/pyroomacoustics/utilities.py
@@ -547,8 +547,10 @@ def fractional_delay(t0):
     """
 
     N = constants.get("frac_delay_length")
+    frac_del_filter = np.hanning(N)*np.sinc(np.arange(N) - (N-1)/2 - t0)
+    frac_del_filter = frac_del_filter/np.max(abs(frac_del_filter))
 
-    return np.hanning(N) * np.sinc(np.arange(N) - (N - 1) / 2 - t0)
+    return frac_del_filter
 
 
 def fractional_delay_filter_bank(delays):

--- a/pyroomacoustics/utilities.py
+++ b/pyroomacoustics/utilities.py
@@ -548,7 +548,7 @@ def fractional_delay(t0):
 
     N = constants.get("frac_delay_length")
     frac_del_filter = np.hanning(N)*np.sinc(np.arange(N) - (N-1)/2 - t0)
-    frac_del_filter = frac_del_filter/np.max(abs(frac_del_filter))
+    frac_del_filter = frac_del_filter/np.max(np.abs(frac_del_filter))
 
     return frac_del_filter
 

--- a/pyroomacoustics/utilities.py
+++ b/pyroomacoustics/utilities.py
@@ -547,10 +547,10 @@ def fractional_delay(t0):
     """
 
     N = constants.get("frac_delay_length")
-    frac_del_filter = np.hanning(N)*np.sinc(np.arange(N) - (N-1)/2 - t0)
-    frac_del_filter = frac_del_filter/np.max(np.abs(frac_del_filter))
+    frac_delay_filter = np.hanning(N)*np.sinc(np.arange(N) - (N-1)/2 - t0)
+    frac_delay_filter = frac_delay_filter/np.max(np.abs(frac_delay_filter))
 
-    return frac_del_filter
+    return frac_delay_filter
 
 
 def fractional_delay_filter_bank(delays):


### PR DESCRIPTION
Current implementation of the Room Impulse Responses (RIRs) contains a critical bug. Namely, there is no normalization of the fractional delay filter. A delay filter has to add a delay without attenuation of the signal. Hence, it gives unexpected amplitudes of the RIRs. It is known that the signal strength decays over distance, without normalization this can not be achieved. On the attached figures you can see results of the current implementation and after improvement.
![Simulated_setup](https://user-images.githubusercontent.com/9136171/89528598-9e385600-d7eb-11ea-8590-37360377a1d3.png)
![Simulated_RIRs_before](https://user-images.githubusercontent.com/9136171/89528611-a1cbdd00-d7eb-11ea-8ecf-9dae362b145f.png)
![Simulated_RIRs_after](https://user-images.githubusercontent.com/9136171/89528621-a42e3700-d7eb-11ea-8597-9a2f0134cc75.png)




