### PR TITLE
Improve the computation of the auxiliary variables in AuxIVA and ILRMA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Bugfix
 
 - Fixes typo in a docstring
 
+Changed
+~~~~~~~
+
+- Improve the computation of the auxiliary variables in AuxIVA and ILRMA.
+  Unnecessary division operations are reduced.
+
 `0.4.2`_ - 2020-09-24
 ---------------------
 

--- a/pyroomacoustics/bss/auxiva.py
+++ b/pyroomacoustics/bss/auxiva.py
@@ -225,8 +225,8 @@ def auxiva(
             # Compute Auxiliary Variable
             # shape: (n_freq, n_chan, n_chan)
             V[:, :, :] = np.matmul(
-                (X * r_inv[None, s, None, :]), np.conj(X.swapaxes(1, 2)) / n_frames
-            )
+                (X * r_inv[None, s, None, :]), np.conj(X.swapaxes(1, 2))
+            ) / n_frames
 
             WV = np.matmul(W_hat, V)
             W[:, s, :] = np.conj(np.linalg.solve(WV, eyes[:, :, s]))

--- a/pyroomacoustics/bss/ilrma.py
+++ b/pyroomacoustics/bss/ilrma.py
@@ -155,7 +155,9 @@ def ilrma(
 
             # Compute Auxiliary Variable
             # shape: (n_freq, n_chan, n_chan)
-            C = np.matmul((X * iR[s, :, None, :]), np.conj(X.swapaxes(1, 2)) / n_frames)
+            C = np.matmul(
+                (X * iR[s, :, None, :]), np.conj(X.swapaxes(1, 2))
+            ) / n_frames
 
             WV = np.matmul(W, C)
             W[:, s, :] = np.conj(np.linalg.solve(WV, eyes[:, :, s]))


### PR DESCRIPTION
I improved the computation of the auxiliary variables of AuxIVA and ILRMA.
The original implementation
```python
V[:, :, :] = np.matmul(
    (X * r_inv[None, s, None, :]), np.conj(X.swapaxes(1, 2)) / n_frames
)
```
performs division operation `n_freq` x `n_frames` x `n_chan` times.
I modified this computation as
```python
V[:, :, :] = np.matmul(
    (X * r_inv[None, s, None, :]), np.conj(X.swapaxes(1, 2))
) / n_frames
```
which only performs division operation  `n_freq` x `n_chan` x `n_chan` times.
Since the runtime of AuxIVA is dominated by the computation of `V`,
this modification makes AuxIVA run much faster.
I tested AuxIVA by using `%timeit` of iPython with `n_frames = 300`, `n_freq = 2049`, `n_chan = 3`, `n_src = 3`.
Before:
```
4.7 s ± 2.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After:
```
4.04 s ± 4.74 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
The implementation of ILRMA is also modified in the same way.

- [ ] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [x] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [ ] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [x] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

(This PR did not modify any documents.)
