### PR TITLE
Bug in computation of SRP cost function

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,16 +32,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Lint with flake8
-      run: |
-        # pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    #- name: Set PATH
-    #  run: echo "::add-path::C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64"
-    #  if: matrix.os == 'windows-latest'
     - name: Build package
       run: |
         python setup.py build_ext --inplace

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Bugfix
 
 - Fixes the Dockerfile so that we don't have to install the build dependencies manually
 - Change the eps for geometry computations from 1e-4 to 1e-5 in ``libroom``
+- Fixes the computation of the cost function of SRP-PHAT doa algorithm (bug reported in #PR197)
 
 Added
 ~~~~~

--- a/pyroomacoustics/doa/srp.py
+++ b/pyroomacoustics/doa/srp.py
@@ -4,6 +4,7 @@ from __future__ import division, print_function
 
 from .doa import *
 
+
 class SRP(DOA):
     """
     Class to apply Steered Response Power (SRP) direction-of-arrival (DoA) for 
@@ -36,15 +37,38 @@ class SRP(DOA):
         Candidate elevation angles (in radians) with respect to z-axis.
         Default is x-y plane search: np.pi/2*np.ones(1)
     """
-    def __init__(self, L, fs, nfft, c=343.0, num_src=1, mode='far', r=None, 
-        azimuth=None, colatitude=None, **kwargs):
 
-        DOA.__init__(self, L=L, fs=fs, nfft=nfft, c=c, num_src=num_src, 
-            mode=mode, r=r, azimuth=azimuth, colatitude=colatitude, **kwargs)
+    def __init__(
+        self,
+        L,
+        fs,
+        nfft,
+        c=343.0,
+        num_src=1,
+        mode="far",
+        r=None,
+        azimuth=None,
+        colatitude=None,
+        **kwargs
+    ):
 
-        self.num_pairs = self.M*(self.M-1)/2
+        DOA.__init__(
+            self,
+            L=L,
+            fs=fs,
+            nfft=nfft,
+            c=c,
+            num_src=num_src,
+            mode=mode,
+            r=r,
+            azimuth=azimuth,
+            colatitude=colatitude,
+            **kwargs
+        )
 
-        #self.mode_vec = np.conjugate(self.mode_vec)
+        self.num_pairs = self.M * (self.M - 1) / 2
+
+        # self.mode_vec = np.conjugate(self.mode_vec)
 
     def _process(self, X):
         """
@@ -63,24 +87,34 @@ class SRP(DOA):
 
         CC = []
         for k in self.freq_bins:
-            CC.append( np.dot(pX[:,k,:], np.conj(pX[:,k,:]).T) )
+            CC.append(np.dot(pX[:, k, :], np.conj(pX[:, k, :]).T))
         CC = np.array(CC)
+
+        M = self.L.shape[1]
+        ar = np.arange(M)
+        av = ar[:, None]
+        mask_diag = av == av.T
+        mask_triu = av <= av.T
+
+        mask_triu2 = (av <= av.T).flatten()
+        mask_diag2 = mask_diag.flatten()[mask_triu2]
+        CC2 = CC.reshape((-1, CC.shape[-2] * CC.shape[-2]))[:, mask_triu2]
 
         for n in range(self.grid.n_points):
 
             # get the mode vector axis: (frequency, microphones)
-            mode_vec = self.mode_vec[self.freq_bins,:,n]
+            mode_vec = self.mode_vec[self.freq_bins, :, n]
 
             # compute the outer product along the microphone axis
-            mode_mat = np.conj(mode_vec[:,:,None]) * mode_vec[:,None,:]
+            mode_mat = np.conj(mode_vec[:, :, None]) * mode_vec[:, None, :]
 
-            # multiply covariance by mode vectors and sum over the frequencies
-            R = np.sum(CC * mode_mat, axis=0)
-
-            # Now sum over all distince microphone pairs
-            sum_val = np.inner(ones, np.dot(np.triu(R, 1), ones))
+            # method 2
+            mode_mat = mode_mat.reshape((-1, M * M))[:, mask_triu2]
+            R = CC2.real * mode_mat.real - CC2.imag * mode_mat.imag
+            R[:, mask_diag2] *= 0.5
+            sum_val = 2.0 * np.sum(R)
 
             # Finally normalize
-            srp_cost[n] = np.abs(sum_val) / self.num_snap/self.num_freq/self.num_pairs
+            srp_cost[n] = sum_val / self.num_snap / self.num_freq / self.num_pairs
 
         self.grid.set_values(srp_cost)

--- a/pyroomacoustics/doa/srp.py
+++ b/pyroomacoustics/doa/srp.py
@@ -90,10 +90,10 @@ class SRP(DOA):
         ar = np.arange(M)
         av = ar[:, None]
 
-        # the two masks here allow to select the upper triangular part
-        # and the diagonal coefficients respectively.
-        # They can be applied on the flattened last two dimensions of a
-        # stack of matrices
+        # the mask here allow to select all the coefficients above
+        # the main diagonal of the covariance matrix
+        # It can be applied on the flattened last two dimensions of the
+        # stack of cov. matrices
         mask_triu = (av < av.T).flatten()
 
         # Flatten the covariance matrices and use the above mask to

--- a/pyroomacoustics/doa/tests/test_doa.py
+++ b/pyroomacoustics/doa/tests/test_doa.py
@@ -2,7 +2,8 @@
 # @author: robin.scheibler@epfl.ch, ivan.dokmanic@epfl.ch, sidney.barthe@epfl.ch
 # @copyright: EPFL-IC-LCAV 2017
 
-from unittest import TestCase
+import unittest
+
 import numpy as np
 from scipy.signal import fftconvolve
 
@@ -12,17 +13,17 @@ import pyroomacoustics as pra
 np.random.seed(0)
 
 # Location of original source
-azimuth = 61. / 180. * np.pi  # 60 degrees
-tol = 0.3 / 180. * np.pi  # 0.3 degrees tolerance for the test
+azimuth = 61.0 / 180.0 * np.pi  # 60 degrees
+tol = 0.3 / 180.0 * np.pi  # 0.3 degrees tolerance for the test
 
 # algorithms parameters
-c = 343.
+c = 343.0
 fs = 16000
 nfft = 256
 freq_bins = np.arange(5, 60)
 
 # circular microphone array, 12 mics, radius 15 cm
-R = pra.circular_2D_array([0, 0], 12, 0., 0.15)
+R = pra.circular_2D_array([0, 0], 12, 0.0, 0.15)
 
 # propagation filter bank
 propagation_vector = -np.array([np.cos(azimuth), np.sin(azimuth)])
@@ -34,54 +35,74 @@ x = np.random.randn((nfft // 2 + 1) * nfft)
 
 # convolve the source signal with the fractional delay filters
 # to get the microphone input signals
-mic_signals = np.array([ fftconvolve(x, filter, mode='same') for filter in filter_bank ])
+mic_signals = np.array([fftconvolve(x, filter, mode="same") for filter in filter_bank])
 X = pra.transform.analysis(mic_signals.T, nfft, nfft // 2, win=np.hanning(nfft))
 X = np.swapaxes(X, 2, 0)
 
-class TestDOA(TestCase):
 
+class TestDOA(unittest.TestCase):
     def test_music(self):
-        doa = pra.doa.algorithms['MUSIC'](R, fs, nfft, c=c)
+        doa = pra.doa.algorithms["MUSIC"](R, fs, nfft, c=c)
         doa.locate_sources(X, freq_bins=freq_bins)
-        print('distance:', pra.doa.circ_dist(azimuth, doa.azimuth_recon))
+        print("distance:", pra.doa.circ_dist(azimuth, doa.azimuth_recon))
         self.assertTrue(pra.doa.circ_dist(azimuth, doa.azimuth_recon) < tol)
 
     def test_srp_phat(self):
-        doa = pra.doa.algorithms['SRP'](R, fs, nfft, c=c)
+        doa = pra.doa.algorithms["SRP"](R, fs, nfft, c=c)
         doa.locate_sources(X, freq_bins=freq_bins)
-        print('distance:', pra.doa.circ_dist(azimuth, doa.azimuth_recon))
+        print("distance:", pra.doa.circ_dist(azimuth, doa.azimuth_recon))
         self.assertTrue(pra.doa.circ_dist(azimuth, doa.azimuth_recon) < tol)
 
+    def test_srp_phat_2ch(self):
+        """
+        Tests that the cost function of SRP is properly computed (PR #197)
+
+        This checks for the presence of a bug that was detected in PR #197.
+        """
+        doa = pra.doa.algorithms["SRP"](R[:, :2], fs, nfft, c=c)
+        i_freq = 10
+        doa.locate_sources(X[:2, :, :], freq_bins=freq_bins[i_freq : i_freq + 1])
+        std_val = np.std(doa.grid.values)
+        self.assertTrue(std_val > 1e-10)
+
     def test_cssm(self):
-        doa = pra.doa.algorithms['CSSM'](R, fs, nfft, c=c)
+        doa = pra.doa.algorithms["CSSM"](R, fs, nfft, c=c)
         doa.locate_sources(X, freq_bins=freq_bins)
-        print('distance:', pra.doa.circ_dist(azimuth, doa.azimuth_recon))
+        print("distance:", pra.doa.circ_dist(azimuth, doa.azimuth_recon))
         self.assertTrue(pra.doa.circ_dist(azimuth, doa.azimuth_recon) < tol)
 
     def test_tops(self):
-        doa = pra.doa.algorithms['TOPS'](R, fs, nfft, c=c)
+        doa = pra.doa.algorithms["TOPS"](R, fs, nfft, c=c)
         doa.locate_sources(X, freq_bins=freq_bins)
-        print('distance:', pra.doa.circ_dist(azimuth, doa.azimuth_recon))
+        print("distance:", pra.doa.circ_dist(azimuth, doa.azimuth_recon))
         self.assertTrue(pra.doa.circ_dist(azimuth, doa.azimuth_recon) < tol)
 
     def test_waves(self):
-        doa = pra.doa.algorithms['WAVES'](R, fs, nfft, c=c)
+        doa = pra.doa.algorithms["WAVES"](R, fs, nfft, c=c)
         doa.locate_sources(X, freq_bins=freq_bins)
-        print('distance:', pra.doa.circ_dist(azimuth, doa.azimuth_recon))
+        print("distance:", pra.doa.circ_dist(azimuth, doa.azimuth_recon))
         self.assertTrue(pra.doa.circ_dist(azimuth, doa.azimuth_recon) < tol)
 
     def test_frida(self):
-        doa = pra.doa.algorithms['FRIDA'](R, fs, nfft, c=c)
+        doa = pra.doa.algorithms["FRIDA"](R, fs, nfft, c=c)
         doa.locate_sources(X, freq_bins=freq_bins)
-        print('distance:', pra.doa.circ_dist(azimuth, doa.azimuth_recon))
+        print("distance:", pra.doa.circ_dist(azimuth, doa.azimuth_recon))
         self.assertTrue(pra.doa.circ_dist(azimuth, doa.azimuth_recon) < tol)
 
-if __name__ == '__main__':
 
+if __name__ == "__main__":
+
+    """
     algo_names = sorted(pra.doa.algorithms.keys())
 
     for algo_name in algo_names:
         doa = pra.doa.algorithms[algo_name](R, fs, nfft, c=c, max_four=4)
         doa.locate_sources(X, freq_bins=freq_bins)
-        print(algo_name, doa.azimuth_recon / np.pi * 180., 
-            pra.doa.circ_dist(azimuth, doa.azimuth_recon) / np.pi * 180.)
+        print(
+            algo_name,
+            doa.azimuth_recon / np.pi * 180.0,
+            pra.doa.circ_dist(azimuth, doa.azimuth_recon) / np.pi * 180.0,
+        )
+    """
+
+    unittest.main()


### PR DESCRIPTION
This PR corrects a bug in the computation of the cost function of the SRP-PHAT DOA algorithm.
The bug was originally reported in PR #197 .

This PR fixes the original bug, improves computational efficiency (although this was not really tested), and adds a test that catches the original bug.

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [ ] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
