### PR TITLE
fix wrong bracketing for negative values in is_inside

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
-Nothing yet.
+- fix wrong bracketing for negative values in is_inside (ShoeBox)
 
 `0.4.3`_ - 2021-02-18
 ---------------------

--- a/pyroomacoustics/room.py
+++ b/pyroomacoustics/room.py
@@ -2549,4 +2549,4 @@ class ShoeBox(Room):
         True if ``pos`` is a point in the room, ``False`` otherwise.
         """
         pos = np.array(pos)
-        return np.all(pos) >= 0 and np.all(pos <= self.shoebox_dim)
+        return np.all(pos >= 0) and np.all(pos <= self.shoebox_dim)


### PR DESCRIPTION
In the Shoebox model, negative values are considered to be in the room. 

Minimal example:

```
import numpy as np
import matplotlib.pyplot as plt
import pyroomacoustics as pra
# Create a 4 by 6 metres shoe box room
room = pra.ShoeBox([4,6])
# Add a source somewhere in the room
room.add_source([2.5, 4.5])
print(room.is_inside([1.0, 3.0]))  # True
print(room.is_inside([1.0, 6.1]))  # False
print(room.is_inside([-1.0, 3.0]))  # True, false is expected
```

- [ ] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [x] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [ ] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [x] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
