### PR TITLE
Using efficient np.linalg.multi_dot

### DIFF
--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -1432,7 +1432,7 @@ class Beamformer(MicrophoneArray):
 
         # compute and return SNR
         num = np.inner(g_val.T, np.dot(R_xx, g_val))
-        denom = np.inner(np.dot(g_val.T, K_nq), g_val)                 
+        denom = np.inner(np.dot(g_val.T, K_nq), g_val)
 
         return num / denom
 

--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -1315,7 +1315,7 @@ class Beamformer(MicrophoneArray):
         # compute and return SNR
         A = np.dot(g_val.T, H[:, :L])
         num = np.dot(A, A.T)
-        denom = np.dot(np.dot(g_val.T, K_nq), g_val)
+        denom = np.linalg.multi_dot([g_val.T, K_nq, g_val])
 
         return num / denom
 
@@ -1395,7 +1395,7 @@ class Beamformer(MicrophoneArray):
         # compute and return SNR
         A = np.dot(g_val.T, H[:, :L])
         num = np.dot(A, A.T)
-        denom = np.linalg.multi_dot(g_val.T, K_nq, g_val)
+        denom = np.linalg.multi_dot([g_val.T, K_nq, g_val])
 
         return num / denom
 
@@ -1432,7 +1432,7 @@ class Beamformer(MicrophoneArray):
 
         # compute and return SNR
         num = np.inner(g_val.T, np.dot(R_xx, g_val))
-        denom = np.inner(np.dot(g_val.T, K_nq), g_val)
+        denom = np.inner(np.linalg.multi_dot([g_val.T, K_nq, g_val])
 
         return num / denom
 
@@ -1505,6 +1505,6 @@ class Beamformer(MicrophoneArray):
         # compute and return SNR
         A = np.dot(g_val.T, H[:, :L])
         num = np.dot(A, A.T)
-        denom = np.linalg.multi_dot(g_val.T, K_nq, g_val)
+        denom = np.linalg.multi_dot([g_val.T, K_nq, g_val])
 
         return num / denom

--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -1505,6 +1505,6 @@ class Beamformer(MicrophoneArray):
         # compute and return SNR
         A = np.dot(g_val.T, H[:, :L])
         num = np.dot(A, A.T)
-        denom = np.dot(np.dot(g_val.T, K_nq), g_val)
+        denom = np.linalg.multi_dot(g_val.T, K_nq, g_val)
 
         return num / denom

--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -1432,7 +1432,7 @@ class Beamformer(MicrophoneArray):
 
         # compute and return SNR
         num = np.inner(g_val.T, np.dot(R_xx, g_val))
-        denom = np.inner(np.linalg.multi_dot([g_val.T, K_nq, g_val])
+        denom = np.inner(np.dot(g_val.T, K_nq), g_val)                 
 
         return num / denom
 

--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -1395,7 +1395,7 @@ class Beamformer(MicrophoneArray):
         # compute and return SNR
         A = np.dot(g_val.T, H[:, :L])
         num = np.dot(A, A.T)
-        denom = np.dot(np.dot(g_val.T, K_nq), g_val)
+        denom = np.linalg.multi_dot(g_val.T, K_nq, g_val)
 
         return num / denom
 

--- a/pyroomacoustics/denoise/subspace.py
+++ b/pyroomacoustics/denoise/subspace.py
@@ -213,7 +213,7 @@ class Subspace(object):
             q1[w, w] = pos_eigenvals[w] / (pos_eigenvals[w] + self.mu)
 
         v_t = np.transpose(-eigenvecs[:, order])
-        self.h_opt[:] = np.real(np.dot(np.dot(np.linalg.pinv(v_t), q1), v_t))
+        self.h_opt[:] = np.real(np.linalg.multi_dot([np.linalg.pinv(v_t), q1, v_t]))
         # self.h_opt = np.dot(np.linalg.lstsq(v_t, q1, rcond=None)[0], v_t)
 
     def update_cov_matrices(self, new_samples):

--- a/pyroomacoustics/doa/cssm.py
+++ b/pyroomacoustics/doa/cssm.py
@@ -157,6 +157,6 @@ class CSSM(MUSIC):
 
             Tj = np.dot(np.c_[A0, B], np.linalg.inv(np.c_[Aj, B]))
 
-            R = R + np.dot(np.dot(Tj, C_hat[j, :, :]), np.conjugate(Tj).T)
+            R = R + np.linalg.multi_dot([Tj, C_hat[j, :, :], np.conjugate(Tj).T])
 
         return R

--- a/pyroomacoustics/doa/music.py
+++ b/pyroomacoustics/doa/music.py
@@ -152,7 +152,7 @@ class MUSIC(DOA):
         for n in range(self.grid.n_points):
             Dc = np.array(self.mode_vec[k, :, n], ndmin=2).T
             Dc_H = np.conjugate(np.array(self.mode_vec[k, :, n], ndmin=2))
-            denom = np.dot(np.dot(Dc_H, cross), Dc)
+            denom = np.linalg.multi_dot([Dc_H, cross, Dc])
             P[n] = 1 / abs(denom)
 
         return P


### PR DESCRIPTION
It is more succinct and effective to refactor code to use np.linalg.multi_dot rather than numerous np.dot routines.
What do you think about this change that has practical value?


- [ ] Are there docstrings ? Do they follow the [numpydoc] (https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ? **There are no docstrings**
- [ ] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ? 
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation). **Yes**
- [ ] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed. **No, this is a refactoring.**
- [ ] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased". **No, this is a refactoring.**

Happy PR :smiley:
