### PR TITLE
Improves documentation for wall creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.idea
 *.DS_Store
 *.wav
+*.so
 build/
 docs/_build
 dist/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Added
 - Randomized image source method for removing sweeping echoes in shoebox rooms.
 - Adds the ``cart2spher`` method in ``pyroomacoustics.doa.utils`` to convert from cartesian
   to spherical coordinates.
+- Example `room_complex_wall_materials.py`
 
 Changed
 ~~~~~~~

--- a/examples/room_complex_wall_materials.py
+++ b/examples/room_complex_wall_materials.py
@@ -1,0 +1,77 @@
+"""
+This examples demonstrates how to build a 3D room for multi-band simulation
+with rich wall materials.
+
+2022 (c) @noahdeetzers, @fakufaku
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+import pyroomacoustics as pra
+
+# Define the materials array
+ceiling_mat = {
+    "description": "Example ceiling material",
+    "coeffs": [0.1, 0.2, 0.1, 0.1, 0.1, 0.05],
+    "center_freqs": [125, 250, 500, 1000, 2000, 4000],
+}
+floor_mat = {
+    "description": "Example floor material",
+    "coeffs": [0.1, 0.2, 0.1, 0.1, 0.1, 0.05],
+    "center_freqs": [125, 250, 500, 1000, 2000, 4000],
+}
+wall_mat = {
+    "description": "Example wall material",
+    "coeffs": [0.1, 0.2, 0.1, 0.1, 0.1, 0.05],
+    "center_freqs": [125, 250, 500, 1000, 2000, 4000],
+}
+
+
+def makeComplexRoom(height):
+    # this creates a more complex room with 9 non-orthogonal sides
+
+    # Creating the array of the 2d room
+    pol = (
+        4
+        * np.array(
+            [[1, 0], [0, 2], [0, 3], [1, 4], [1.5, 3.8], [2, 4], [3, 3], [3, 2], [2, 0]]
+        ).T
+    )
+
+    # initial acoustic coeffs
+    m = pra.make_materials(*[(wall_mat,) for i in range(pol.shape[1])])
+
+    room = pra.Room.from_corners(
+        pol,
+        absorption=None,
+        fs=8000,
+        t0=0.0,
+        max_order=1,
+        sigma2_awgn=None,
+        sources=None,
+        mics=None,
+        materials=m,
+    )
+
+    # Create the 3D room by extruding the 2D by 3 meters
+    me = pra.make_materials(floor=(floor_mat,), ceiling=(ceiling_mat,))
+    room.extrude(height, materials=me)
+
+    # Add a source somewhere in the room
+    room.add_source([3, 3, 0.5])
+
+    # Create a linear array beamformer with 4 microphones
+    # Place an array of two microphones
+    R = np.array([[3.0, 2.2], [2.25, 2.1], [0.6, 0.55]])
+    room.add_microphone_array(pra.MicrophoneArray(R, room.fs))
+
+    return room
+
+
+room = makeComplexRoom(5)
+
+room.image_source_model()
+fig, ax = room.plot()
+ax.set_xlim([0, 12])
+ax.set_ylim([0, 12])
+ax.set_zlim([0, 12])
+plt.show()

--- a/pyroomacoustics/parameters.py
+++ b/pyroomacoustics/parameters.py
@@ -445,6 +445,30 @@ def make_materials(*args, **kwargs):
     If only keyword arguments are provided, only the dict is returned.
     If both are provided, both are returned.
     If no argument is provided, an empty list is returned.
+
+    .. code-block:: python
+        :linenos:
+
+        # energy absorption parameters
+        floor_eabs = {
+            "description": "Example floor material",
+            "coeffs": [0.1, 0.2, 0.1, 0.1, 0.1, 0.05],
+            "center_freqs": [125, 250, 500, 1000, 2000, 4000],
+        }
+
+        # scattering parameters
+        audience_scat = {
+            "description": "Theatre Audience",
+            "coeffs": [0.3, 0.5, 0.6, 0.6, 0.7, 0.7, 0.7]
+            "center_freqs": [125, 250, 500, 1000, 2000, 4000],
+        }
+
+        # create a list of materials
+        my_mat_list = pra.make_materials((floor_eabs, audience_scat))
+
+        # create a dict of materials
+        my_mat_dict = pra.make_materials(floor=(floor_abs, audience_scat))
+
     """
 
     ret_args = []

--- a/pyroomacoustics/room.py
+++ b/pyroomacoustics/room.py
@@ -450,6 +450,9 @@ be defined by chosing a material from the :doc:`materials database<pyroomacousti
 
 We can use different materials for different walls. In this case, the materials should be
 provided in a dictionary. For a shoebox room, this can be done as follows.
+We use the :py:func:`~pyroomacoustics.parameters.make_materials` helper
+function to create a ``dict`` of
+:py:class:`~pyroomacoustics.parameters.Material` objects.
 
 .. code-block:: python
 
@@ -465,6 +468,10 @@ provided in a dictionary. For a shoebox room, this can be done as follows.
     room = pra.ShoeBox(
         [9, 7.5, 3.5], fs=16000, materials=m, max_order=17, air_absorption=True, ray_tracing=True
     )
+
+For a more complete example see
+`examples/room_complex_wall_materials.py
+<https://github.com/LCAV/pyroomacoustics/blob/master/examples/room_complex_wall_materials.py>`_.
 
 .. note::
 
@@ -1143,7 +1150,26 @@ class Room(object):
             list of corners, must be antiClockwise oriented
         absorption: float array or float
             list of absorption factor for each wall or single value
-            for all walls
+            for all walls (deprecated)
+        fs: int, optional
+            The sampling frequency in Hz. Default is 8000.
+        t0: float, optional
+            The global starting time of the simulation in seconds. Default is 0.
+        max_order: int, optional
+            The maximum reflection order in the image source model. Default is 1,
+            namely direct sound and first order reflections.
+        sigma2_awgn: float, optional
+            The variance of the additive white Gaussian noise added during
+            simulation. By default, none is added.
+        sources: list of SoundSource objects, optional
+            Sources to place in the room. Sources can be added after room creating
+            with the `add_source` method by providing coordinates.
+        mics: MicrophoneArray object, optional
+            The microphone array to place in the room. A single microphone or
+            microphone array can be added after room creation with the
+            `add_microphone_array` method.
+        kwargs: key, value mappings
+            Other keyword arguments accepted by the :py:class:`~pyroomacoustics.room.Room` class
 
         Returns
         -------

--- a/pyroomacoustics/room.py
+++ b/pyroomacoustics/room.py
@@ -1150,7 +1150,7 @@ class Room(object):
             list of corners, must be antiClockwise oriented
         absorption: float array or float
             list of absorption factor for each wall or single value
-            for all walls (deprecated)
+            for all walls (deprecated, use ``materials`` instead)
         fs: int, optional
             The sampling frequency in Hz. Default is 8000.
         t0: float, optional


### PR DESCRIPTION
This PR improves the documentation for creating walls with multi-band absorption and scattering coefficients.
* docstring of `make_materials`
* docstring of `from_corners`
* adds example `room_complex_wall_materials.py`

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
