### PR TITLE
fix(sec): upgrade sphinx to 3.0.4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=1.6.2
+sphinx>=3.0.4
 mock>=2.0
 sphinx_rtd_theme
 sphinxcontrib-napoleon


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in sphinx 1.6.2
- [CVE-2020-11022](https://www.oscs1024.com/hd/CVE-2020-11022)


### What did I do？
Upgrade sphinx from 1.6.2 to 3.0.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS