### PR TITLE
Colatitude calculation fix

### DIFF
--- a/pyroomacoustics/tests/test_angle_function.py
+++ b/pyroomacoustics/tests/test_angle_function.py
@@ -7,20 +7,20 @@ from pyroomacoustics import angle_function
 pi = np.pi
 
 # for 3-D coordinates
-a1 = np.array([[0, 0, 1], [0, 0, 1], [0, 1, 1]])
+a1 = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
 a2 = np.array([[0], [0], [1]])
 a3 = np.array([0, 0, 1]).T
 
 b1 = np.array([[0], [0], [0]])
-b2 = np.array([1, -1, 1]).T
+b2 = np.array([1, 0, 0]).T
 
 
-a1_b1 = np.array([[0, 0, pi / 4], [0, 0, pi / 4]])
-a1_b2 = np.array([[3 * pi / 4, 3 * pi / 4, pi / 2], [3 * pi / 4, pi / 2, pi / 2]])
+a1_b1 = np.array([[0, pi / 2, 0], [0, pi / 2, pi / 2]])
+a1_b2 = np.array([[pi, 3 * pi / 4, 0], [pi / 4, pi / 2, 0]])
 a2_b1 = np.array([[0], [0]])
-a2_b2 = np.array([[3 * pi / 4], [pi / 2]])
+a2_b2 = np.array([[pi], [pi / 4]])
 a3_b1 = np.array([[0], [0]])
-a3_b2 = np.array([[3 * pi / 4], [pi / 2]])
+a3_b2 = np.array([[pi], [pi / 4]])
 
 
 # for 2-D coordinates

--- a/pyroomacoustics/utilities.py
+++ b/pyroomacoustics/utilities.py
@@ -808,7 +808,7 @@ def angle_function(s1, v2):
         z_vals = s1[2]
 
         colatitude = np.arctan2(
-            ((x_vals - x2) ** 2 + (y_vals - y2) ** 2) ** 1 / 2, (z_vals - z2)
+            ((x_vals - x2) ** 2 + (y_vals - y2) ** 2) ** (1 / 2), (z_vals - z2)
         )
 
     # colatitude calculation for 2-D coordinates


### PR DESCRIPTION
### Description
This update fixed the colatitude calculation. A missing parenthesis was added, and the associated tests were adjusted accordingly.

### Code Change
**Previous Code:**
```python
colatitude = np.arctan2(
    ((x_vals - x2) ** 2 + (y_vals - y2) ** 2) ** 1 / 2, (z_vals - z2)
)
```
**Updated Code:**
```python
colatitude = np.arctan2(
    ((x_vals - x2) ** 2 + (y_vals - y2) ** 2) ** (1 / 2), (z_vals - z2)
)
```
### Implications
The absence of parenthesis around `1 / 2` led to miscalculations of the colatitude angle. This is particularly relevant in simulations involving Cardioid or Hypercardioid microphones or in case of directional sources.