### PR TITLE
metrics.py: fix compatibility with scipy >=1.13

### DIFF
--- a/pyroomacoustics/metrics.py
+++ b/pyroomacoustics/metrics.py
@@ -2,7 +2,12 @@ import os
 import platform
 
 import numpy as np
-from scipy.signal import hann
+
+try:
+    from scipy.signal import hann
+except ImportError:
+    from scipy.signal.windows import hann
+
 from scipy.stats import binom as _binom
 from scipy.stats import norm as _norm
 


### PR DESCRIPTION
As of scipy v1.13, the `hann` window has been removed from `scipy.signals` and is now only accessible through `scipy.signals.windows`. This PR accounts for this move so that pyroomacoustics will work with the latest scipy versions.

Closes #342

- [ ] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [ ] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [ ] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [ ] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
