### PR TITLE
robustifies the RT60 computation function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,12 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
-Nothing yet
+Changed
+~~~~~~~
+
+- Extra parameter ``energy_thresh`` added to ``pyroomacoustics.experimental.measure_rt60``.
+  The energy tail beyond this threshold is discarded which is useful for noisy RIR
+  measurements. The default value is 0.95.
 
 `0.7.4`_ - 2024-04-25
 ---------------------

--- a/pyroomacoustics/bss/fastmnmf.py
+++ b/pyroomacoustics/bss/fastmnmf.py
@@ -161,9 +161,7 @@ def fastmnmf(
         Y_FTM = np.einsum("nft, nfm -> ftm", lambda_NFT, G_NFM)
 
         # update G_NFM (diagonal element of spatial covariance matrices)
-        numerator = np.einsum(
-            "nft, ftm -> nfm", lambda_NFT, Qx_power_FTM / (Y_FTM**2)
-        )
+        numerator = np.einsum("nft, ftm -> nfm", lambda_NFT, Qx_power_FTM / (Y_FTM**2))
         denominator = np.einsum("nft, ftm -> nfm", lambda_NFT, 1 / Y_FTM) + eps
         G_NFM *= np.sqrt(numerator / denominator)
         Y_FTM = np.einsum("nft, nfm -> ftm", lambda_NFT, G_NFM)

--- a/pyroomacoustics/experimental/rt60.py
+++ b/pyroomacoustics/experimental/rt60.py
@@ -33,7 +33,7 @@ References
 import numpy as np
 
 
-def measure_rt60(h, fs=1, decay_db=60, energy_thres=1.0, plot=False, rt60_tgt=None):
+def measure_rt60(h, fs=1, decay_db=60, energy_thres=0.95, plot=False, rt60_tgt=None):
     """
     Analyze the RT60 of an impulse response. Optionaly plots some useful information.
 


### PR DESCRIPTION
This modification adds a new parameter to the `measure_rt60` routine that allows to discard long noisy tails in measured RIR.

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [X] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
