### PR TITLE
Fixes bugs in circular_microphone_array_xyplane and Room.plot_rir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,13 @@ Changed
   The energy tail beyond this threshold is discarded which is useful for noisy RIR
   measurements. The default value is 0.95.
 
+Bugfix
+~~~~~~
+
+- Fixes a bug in ``beamforming.circular_microphone_array_xyplane`` (#348)
+- Fixes a bug in ``room.Room.plot_rir`` where the x-axis would have the wrong
+  ticks when called with ``kind="tf"``
+
 `0.7.4`_ - 2024-04-25
 ---------------------
 

--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -298,7 +298,7 @@ def circular_microphone_array_xyplane(
     MicrophoneArray object
     """
 
-    R = circular_2D_array(center=center[:1], M=M, phi0=phi0, radius=radius)
+    R = circular_2D_array(center=center[:2], M=M, phi0=phi0, radius=radius)
     if len(center) == 3:
         colatitude = 90
         R = np.concatenate((R, np.ones((1, M)) * center[2]))

--- a/pyroomacoustics/room.py
+++ b/pyroomacoustics/room.py
@@ -1887,7 +1887,7 @@ class Room(object):
                 ax.plot(np.arange(len(h)) / float(self.fs / 1000), h)
             elif kind == "tf":
                 H = 20.0 * np.log10(abs(np.fft.rfft(h)) + 1e-15)
-                freq = np.arange(H.shape[0]) / h.shape[0] * (self.fs * 1000)
+                freq = np.arange(H.shape[0]) / h.shape[0] * (self.fs / 1000)
                 ax.plot(freq, H)
             elif kind == "spec":
                 h = h + np.random.randn(*h.shape) * 1e-15

--- a/pyroomacoustics/tests/test_issue_348.py
+++ b/pyroomacoustics/tests/test_issue_348.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+import pyroomacoustics as pra
+
+
+def test_circular_microphone_array_xyplane():
+    # Create a circular microphone array
+    R = 1.0  # radius
+    M = 2  # number of microphones
+    center = np.array([1.0, 0.0, 0.0])  # center of the array
+
+    mic_array = pra.circular_microphone_array_xyplane(
+        center=center, M=M, phi0=0.0, radius=R, fs=16000
+    )
+
+    # what it should be
+    R_ref = np.array([[2.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+
+    assert np.allclose(mic_array.R, R_ref)


### PR DESCRIPTION
Bugfixes:
1. #348 an indexing error in `circular_microphone_array_xyplane`
2. The granularity of the x-ticks in `Room.plot_rir(kind="tf")` was wrong

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [X] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:
