### PR TITLE
Fixes call to deprecated scipy.integrate.trapz function.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Bugfix
 - Fixes a bug when plotting an anechoic room
 - Fixes a buggy assert from ``rir_build.cpp``
 - Makes the build system consistent for all source files in ``pyroomacoustics/libroom_src``
+- Fixes a call to a deprecated function of scipy.integrate in ``pyroomacoustics/denoise/iterative_wiener`` (issue #362)
 
 `0.7.6`_ - 2024-08-05
 ---------------------

--- a/pyroomacoustics/denoise/iterative_wiener.py
+++ b/pyroomacoustics/denoise/iterative_wiener.py
@@ -337,7 +337,14 @@ def compute_squared_gain(a, noise_psd, y):
     d_omega = 2 * np.pi / 1000
     omega_vals = np.arange(-np.pi, np.pi, d_omega)
     vec_integrand = np.vectorize(_lpc_all_pole)
-    integral = integrate.trapz(vec_integrand(omega_vals), omega_vals)
+
+    try:
+        integral = integrate.trapezoid(vec_integrand(omega_vals), omega_vals)
+    except AttributeError:
+        # older versions of scipy do not have the function 'trapezoid'
+        # fall back to the legacy function name
+        integral = integrate.trapz(vec_integrand(omega_vals), omega_vals)
+
     return rhs * 2 * np.pi / N / integral
 
 

--- a/pyroomacoustics/denoise/tests/test_iterative_wiener.py
+++ b/pyroomacoustics/denoise/tests/test_iterative_wiener.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pyroomacoustics as pra
+
+
+def test_iterative_wiener():
+    """
+    A simple functional test that the call does not produce any errors.
+    """
+    # parameters
+    num_blocks = 20
+    nfft = 512
+    hop = nfft // 2
+
+    # create a dummy signal
+    blocks = np.random.randn(num_blocks, hop)
+
+    # initialize STFT and IterativeWiener objects
+    stft = pra.transform.STFT(nfft, hop=hop, analysis_window=pra.hann(nfft))
+    scnr = pra.denoise.IterativeWiener(
+        frame_len=nfft, lpc_order=20, iterations=2, alpha=0.8, thresh=0.01
+    )
+
+    # apply block-by-block
+    processed_blocks = []
+    for n in range(num_blocks):
+
+        # go to frequency domain, 50% overlap
+        stft.analysis(blocks[n])
+
+        # compute wiener output
+        X = scnr.compute_filtered_output(
+            current_frame=stft.fft_in_buffer, frame_dft=stft.X
+        )
+
+        # back to time domain
+        mono_denoised = stft.synthesis(X)
+        processed_blocks.append(mono_denoised)

--- a/pyroomacoustics/denoise/tests/test_iterative_wiener.py
+++ b/pyroomacoustics/denoise/tests/test_iterative_wiener.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import pyroomacoustics as pra
 
 


### PR DESCRIPTION
Replaces call to `scipy.integrate.trapz` (deprecated) by `scipy.integrate.trapezoid` (new).

This fixes issue #362.

- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".
