### PR TITLE
Makes the resample backend configurable to avoid soxr dependency.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,13 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
-Nothing yet
+Changed
+~~~~~~~
+
+- Makes the ``pyroomacoustics.utilities.resample`` backend is made configurable
+  to avoid ``soxr`` dependency. The resample backend is configurable to
+  ``soxr``, ``samplerate``, if these packages are available, and otherwise
+  falls back to ``scipy.signal.resample_poly``.
 
 `0.8.1`_ - 2024-10-30
 ---------------------

--- a/examples/directivities/simulation_with_measured_directivity.py
+++ b/examples/directivities/simulation_with_measured_directivity.py
@@ -50,6 +50,7 @@ l) Vibrolux_2x10inch
 """
 
 import matplotlib.pyplot as plt
+
 import pyroomacoustics as pra
 from pyroomacoustics.directivities import (
     Cardioid,

--- a/examples/directivities/simulation_with_measured_directivity.py
+++ b/examples/directivities/simulation_with_measured_directivity.py
@@ -50,7 +50,6 @@ l) Vibrolux_2x10inch
 """
 
 import matplotlib.pyplot as plt
-
 import pyroomacoustics as pra
 from pyroomacoustics.directivities import (
     Cardioid,

--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -418,6 +418,7 @@ class MicrophoneArray(object):
             raise NameError("The signals should be a 2D array.")
 
         if fs != self.fs:
+            self.signals = u.resample(signals, fs, self.fs)
             try:
                 import samplerate
 

--- a/pyroomacoustics/parameters.py
+++ b/pyroomacoustics/parameters.py
@@ -82,6 +82,7 @@ _constants_default = {
     "octave_bands_n_fft": 512,
     "octave_bands_base_freq": 125.0,
     "octave_bands_keep_dc": False,
+    "resample_backend": "soxr",
 }
 
 

--- a/pyroomacoustics/tests/test_resample.py
+++ b/pyroomacoustics/tests/test_resample.py
@@ -1,0 +1,49 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pyroomacoustics as pra
+import pytest
+
+
+@pytest.mark.parametrize(
+    "fs_in, fs_out, backend",
+    [
+        (240, 160, "soxr"),
+        (240, 160, "samplerate"),
+        (240, 160, "scipy"),
+    ],
+)
+def test_downsample(fs_in, fs_out, backend):
+    """Idea use a sine above Nyquist of fs_out. It should disappear."""
+    assert fs_in > fs_out
+    f_sine = fs_out / 2.0 + (fs_in - fs_out) / 2.0 * 0.95
+    time = np.arange(fs_in * 10) / fs_in
+    signal_in = np.sin(2.0 * np.pi * time * f_sine)
+    signal_out = pra.resample(signal_in, fs_in, fs_out, backend=backend)
+
+    assert abs(signal_out).mean() < 1e-3
+
+
+if __name__ == "__main__":
+
+    # Reads the file containing the Eigenmike's directivity measurements
+    eigenmike = pra.MeasuredDirectivityFile("EM32_Directivity")
+
+    fs_tgt = 16000
+    fs_file = eigenmike.fs
+
+    print(f"{fs_file=} {fs_tgt=}")
+
+    rir_original = eigenmike.impulse_responses[10, 20]
+    time_file = np.arange(rir_original.shape[0]) / fs_file
+
+    rirs = {}
+    for backend in ["soxr", "samplerate", "scipy"]:
+        rirs[backend] = pra.resample(rir_original, fs_file, fs_tgt, backend=backend)
+
+    fig, ax = plt.subplots(1, 1)
+    ax.plot(time_file, rir_original, label="Original")
+    for idx, (backend, rir) in enumerate(rirs.items()):
+        time_rir = np.arange(rir.shape[0]) / fs_tgt
+        ax.plot(time_rir, rir, label=backend, linewidth=(3 - idx))
+    ax.legend()
+    plt.show()

--- a/pyroomacoustics/tests/test_resample.py
+++ b/pyroomacoustics/tests/test_resample.py
@@ -1,7 +1,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
-import pyroomacoustics as pra
 import pytest
+
+import pyroomacoustics as pra
 
 
 @pytest.mark.parametrize(

--- a/pyroomacoustics/tests/test_resample.py
+++ b/pyroomacoustics/tests/test_resample.py
@@ -13,6 +13,7 @@ import pyroomacoustics as pra
 @pytest.mark.parametrize(
     "fs_in, fs_out, backend",
     [
+        (240, 160, None),
         (240, 160, "soxr"),
         (240, 160, "samplerate"),
         (240, 160, "scipy"),
@@ -33,6 +34,7 @@ def test_downsample(fs_in, fs_out, backend):
 @pytest.mark.parametrize(
     "fs_in, fs_out, backend",
     [
+        (160, 240, None),
         (160, 240, "soxr"),
         (160, 240, "samplerate"),
         (160, 240, "scipy"),

--- a/pyroomacoustics/tests/test_resample.py
+++ b/pyroomacoustics/tests/test_resample.py
@@ -1,3 +1,8 @@
+"""
+Very basic tests to verify that all resampling backends
+can be called and are doing their job.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -16,35 +21,78 @@ import pyroomacoustics as pra
 def test_downsample(fs_in, fs_out, backend):
     """Idea use a sine above Nyquist of fs_out. It should disappear."""
     assert fs_in > fs_out
-    f_sine = fs_out / 2.0 + (fs_in - fs_out) / 2.0 * 0.95
+    f_sine = fs_out / 2.0 + (fs_in - fs_out) / 2.0 * 0.75
     time = np.arange(fs_in * 10) / fs_in
     signal_in = np.sin(2.0 * np.pi * time * f_sine)
+    signal_in = signal_in * np.hanning(signal_in.shape[0])
     signal_out = pra.resample(signal_in, fs_in, fs_out, backend=backend)
 
-    assert abs(signal_out).mean() < 1e-3
+    assert abs(signal_out).max() < 1e-3
+
+
+@pytest.mark.parametrize(
+    "fs_in, fs_out, backend",
+    [
+        (160, 240, "soxr"),
+        (160, 240, "samplerate"),
+        (160, 240, "scipy"),
+    ],
+)
+def test_upsample(fs_in, fs_out, backend):
+    """Idea use a sine above Nyquist of fs_out. It should disappear."""
+    assert fs_in < fs_out
+
+    # make a random signal
+    signal_in = np.random.randn(10 * fs_in)
+    signal_in = signal_in * np.hanning(signal_in.shape[0])
+
+    signal_out = pra.resample(signal_in, fs_in, fs_out, backend=backend)
+
+    # the test relies on upper frequency being empty
+    f_cut = fs_in / 2.0 + (fs_out - fs_in) / 2.0 * 0.75
+    signal_out_filt = pra.highpass(signal_out, fs_out, fc=f_cut)
+
+    assert abs(signal_out_filt).max() < 1e-3
 
 
 if __name__ == "__main__":
 
+    test_cases = []
+
+    # Test 1 is the eigenmike impulse response
     # Reads the file containing the Eigenmike's directivity measurements
     eigenmike = pra.MeasuredDirectivityFile("EM32_Directivity")
-
     fs_tgt = 16000
     fs_file = eigenmike.fs
+    test_cases.append((fs_file, fs_tgt, eigenmike.impulse_responses[0, 0]))
 
-    print(f"{fs_file=} {fs_tgt=}")
+    # Test 2 is a sine
+    fs_in = 240
+    fs_out = 160
+    f_sine = fs_out / 2.0 + (fs_in - fs_out) / 2.0 * 0.95
+    time = np.arange(fs_in * 10) / fs_in
+    signal_in = np.sin(2.0 * np.pi * time * f_sine)
+    signal_in = signal_in * np.hanning(signal_in.shape[0])
+    test_cases.append((fs_in, fs_out, signal_in))
 
-    rir_original = eigenmike.impulse_responses[10, 20]
-    time_file = np.arange(rir_original.shape[0]) / fs_file
+    # Test 3 is some random noise
+    np.random.seed(0)
+    fs_in = 160
+    fs_out = 240
+    signal_in = np.random.randn(fs_in * 10)
+    test_cases.append((fs_in, fs_out, signal_in))
 
-    rirs = {}
-    for backend in ["soxr", "samplerate", "scipy"]:
-        rirs[backend] = pra.resample(rir_original, fs_file, fs_tgt, backend=backend)
+    for fs_in, fs_out, rir_original in test_cases:
+        time_file = np.arange(rir_original.shape[0]) / fs_file
 
-    fig, ax = plt.subplots(1, 1)
-    ax.plot(time_file, rir_original, label="Original")
-    for idx, (backend, rir) in enumerate(rirs.items()):
-        time_rir = np.arange(rir.shape[0]) / fs_tgt
-        ax.plot(time_rir, rir, label=backend, linewidth=(3 - idx))
-    ax.legend()
-    plt.show()
+        rirs = {}
+        for backend in ["soxr", "samplerate", "scipy"]:
+            rirs[backend] = pra.resample(rir_original, fs_file, fs_tgt, backend=backend)
+
+        fig, ax = plt.subplots(1, 1)
+        ax.plot(time_file, rir_original, label="Original")
+        for idx, (backend, rir) in enumerate(rirs.items()):
+            time_rir = np.arange(rir.shape[0]) / fs_tgt
+            ax.plot(time_rir, rir, label=backend, linewidth=(3 - idx))
+        ax.legend()
+        plt.show()

--- a/setup.py
+++ b/setup.py
@@ -186,13 +186,23 @@ setup_kwargs = dict(
     # Libroom C extension
     ext_modules=ext_modules,
     # Necessary to keep the source files
-    package_data={"pyroomacoustics": ["*.pxd", "*.pyx", "data/materials.json"]},
+    package_data={
+        "pyroomacoustics": [
+            "*.pxd",
+            "*.pyx",
+            "data/materials.json",
+            "data/sofa_files.json",
+            "data/sofa/AKG_c480_c414_CUBE.sofa",
+            "data/sofa/EM32_Directivity.sofa",
+            "data/sofa/mit_kemar_large_pinna.sofa",
+            "data/sofa/mit_kemar_normal_pinna.sofa",
+        ]
+    },
     install_requires=[
         "Cython",
         "numpy>=1.13.0",
         "scipy>=0.18.0",
         "pybind11>=2.2",
-        "soxr",
     ],
     cmdclass={"build_ext": BuildExt},  # taken from pybind11 example
     zip_safe=False,


### PR DESCRIPTION
It is undesirable to have a hard dependency on [soxr](https://github.com/dofuuz/python-soxr).
To avoid this, the `utilities.resample` function is given an extra `backend` argument and `soxr`, `samplerate`, or `scypy.signal.resample_poly` can be used.
The default is package wide configurable via, e.g., `constants.set("resample_backend", "soxr")`.

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [ ] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".
