### PR TITLE
Fixes a bug in grid where the cartesian coordinate array is not set properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Bugfix
   directivity to ``Room.add_microphone_array``, the directivity was dropped
   from the object.
 
+- Fixes issue #380: Caused by the attribute ``cartesian`` of ``GridSphere`` not
+  being set properly when the grid is only initialized with a number of points.
+
 `0.8.2`_ - 2024-11-06
 ---------------------
 

--- a/pyroomacoustics/doa/grid.py
+++ b/pyroomacoustics/doa/grid.py
@@ -209,12 +209,11 @@ class GridSphere(Grid):
             # If no list was provided, samples points on the sphere
             # as uniformly as possible
 
-            self.x, self.y, self.z = fibonacci_spherical_sampling(n_points)
+            self.x[:], self.y[:], self.z[:] = fibonacci_spherical_sampling(n_points)
 
             # Create convenient arrays
             # to access both in cartesian and spherical coordinates
-            self.azimuth[:] = np.arctan2(self.y, self.x)
-            self.colatitude[:] = np.arctan2(np.sqrt(self.x**2 + self.y**2), self.z)
+            self.azimuth[:], self.colatitude[:], _ = cart2spher(self.cartesian)
 
         self._neighbors = None
         if precompute_neighbors:


### PR DESCRIPTION
This happens when creating the object with the number of desired point as the single parameter (issue #380).

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

