### PR TITLE
Fixes from_corner/extrude for mixed single/multi-band materials

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,12 @@ Bugfix
   directivity to ``Room.add_microphone_array``, the directivity was dropped
   from the object.
 
+- Fixes issues #381: When creating a room with from_corners with multi-band
+  material, and then making it 3D with ``extrude`` with a single band material
+  for the floor and ceiling, an error would occur.
+  After the fix, the materials for floor and ceiling are automatically extended
+  to multi-band, as expected.
+
 - Fixes issue #380: Caused by the attribute ``cartesian`` of ``GridSphere`` not
   being set properly when the grid is only initialized with a number of points.
 
@@ -30,7 +36,7 @@ Bugfix
 Changed
 ~~~~~~~
 
-- Makes the ``pyroomacoustics.utilities.resample`` backend is made configurable
+- Makes the ``pyroomacoustics.utilities.resample`` backend configurable
   to avoid ``soxr`` dependency. The resample backend is configurable to
   ``soxr``, ``samplerate``, if these packages are available, and otherwise
   falls back to ``scipy.signal.resample_poly``.

--- a/pyroomacoustics/tests/test_from_corners_extrude.py
+++ b/pyroomacoustics/tests/test_from_corners_extrude.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+
+import pyroomacoustics as pra
+
+_FS = 16000
+_MAX_ORDER = 3
+
+
+def test_from_corner_extrude():
+
+    room_dim = [3, 4, 5]
+    # This test is sensitive to the selection of this value.
+    # If some symmetries are present, for some reasons differences between
+    # the two simulated methods happen.
+    src_loc = [1.001, 0.999, 1.002]
+    mic_loc = [2, 3, 4]
+    mat = pra.Material(energy_absorption=0.1)
+
+    room_ref = pra.ShoeBox(room_dim, fs=_FS, max_order=_MAX_ORDER, materials=mat)
+    room_ref.add_source(src_loc).add_microphone(mic_loc)
+    room_ref.compute_rir()
+
+    # Now construct the same room with the other set of primitives.
+    corners = np.array(
+        [[0, 0], [room_dim[0], 0], [room_dim[0], room_dim[1]], [0, room_dim[1]]]
+    ).T
+    room = pra.Room.from_corners(corners, fs=_FS, max_order=_MAX_ORDER, materials=mat)
+    room.extrude(height=room_dim[2], materials=mat)
+    room.add_source(src_loc).add_microphone(mic_loc)
+    room.compute_rir()
+
+    assert np.allclose(room_ref.rir[0][0], room.rir[0][0], rtol=1e-4, atol=1e-4)
+
+
+def test_from_corner_extrude_different_materials():
+
+    room_dim = [3, 4, 5]
+    # This test is sensitive to the selection of this value.
+    # If some symmetries are present, for some reasons differences between
+    # the two simulated methods happen.
+    src_loc = [1.001, 0.999, 1.002]
+    mic_loc = [2, 3, 4]
+    mat1 = "hard_surface"
+    mat2 = 0.1
+
+    materials = pra.make_materials(
+        east=mat1, west=mat1, south=mat1, north=mat1, floor=mat2, ceiling=mat2
+    )
+    room_ref = pra.ShoeBox(room_dim, fs=_FS, max_order=_MAX_ORDER, materials=materials)
+    room_ref.add_source(src_loc).add_microphone(mic_loc)
+    room_ref.compute_rir()
+
+    # Now construct the same room with the other set of primitives.
+    corners = np.array(
+        [[0, 0], [room_dim[0], 0], [room_dim[0], room_dim[1]], [0, room_dim[1]]]
+    ).T
+    room = pra.Room.from_corners(
+        corners,
+        fs=_FS,
+        max_order=_MAX_ORDER,
+        materials=pra.Material(energy_absorption=mat1),
+    )
+    room.extrude(height=room_dim[2], materials=pra.Material(energy_absorption=mat2))
+    room.add_source(src_loc).add_microphone(mic_loc)
+    room.compute_rir()
+
+    assert np.allclose(room_ref.rir[0][0], room.rir[0][0], rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
Fixes issues #381.

When creating a room with `from_corners` with multi-band material, and then making it 3D with `extrude` with a single band material for the floor and ceiling, an error would occur.
After the fix, the materials for floor and ceiling are automatically extended
to multi-band, as expected.

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

