### PR TITLE
Fix missing URLError import statement

### DIFF
--- a/pyroomacoustics/datasets/utils.py
+++ b/pyroomacoustics/datasets/utils.py
@@ -22,7 +22,6 @@
 # You should have received a copy of the MIT License along with this program. If
 # not, see <https://opensource.org/licenses/MIT>.
 
-import bz2
 import os
 import tarfile
 from pathlib import Path

--- a/pyroomacoustics/datasets/utils.py
+++ b/pyroomacoustics/datasets/utils.py
@@ -27,11 +27,11 @@ import tarfile
 from pathlib import Path
 
 try:
-    from urllib.request import urlopen, urlretrieve
     from urllib.error import URLError
+    from urllib.request import urlopen, urlretrieve
 except ImportError:
     # support for python 2.7, should be able to remove by now
-    from urllib import urlopen, urlretrieve, URLError
+    from urllib import URLError, urlopen, urlretrieve
 
 
 class AttrDict(object):

--- a/pyroomacoustics/datasets/utils.py
+++ b/pyroomacoustics/datasets/utils.py
@@ -28,9 +28,10 @@ from pathlib import Path
 
 try:
     from urllib.request import urlopen, urlretrieve
+    from urllib.error import URLError
 except ImportError:
     # support for python 2.7, should be able to remove by now
-    from urllib import urlopen, urlretrieve
+    from urllib import urlopen, urlretrieve, URLError
 
 
 class AttrDict(object):

--- a/pyroomacoustics/datasets/utils.py
+++ b/pyroomacoustics/datasets/utils.py
@@ -128,11 +128,10 @@ def download_multiple(files_dict, overwrite=False, verbose=False, no_fail=False)
 
         try:
             urlretrieve(url, path)
-        except URLError:
+        except URLError as exc:
             if no_fail:
                 continue
-            else:
-                raise URLError(f"Failed to download {url}")
+            raise URLError(f"Failed to download {url}") from exc
 
         if verbose:
             print(" done.")


### PR DESCRIPTION
Hi all, I found that there was a missing import statement in `datasets/utils.py` so if there is an error while downloading a sofa file the code raises an exception saying that `URLError` is not found instead of either skipping silently or re-raising the exception. So here is a tiny PR to fix this. I've also took the liberty to base the re-raised exception on the caught one to keep the original error message in the new exception, as it might give the end user insight on why the URL request failed.

This is my first PR for this repo so please let me know if it needs some changes in code style or whatever 🙂 

That also lead me to some other observations about the whole handling of SOFA files: why are some files directly included in the repo and some other are missing and must be fetched remotely? Maybe it would make sense to leave the user the choice at the moment of creating the SOFA database which are the files that they will actually need? In my case I only needed to access the files that were already part of the library when you install it but I was still blocked because of this failing URL request. If those questions are out of scope for this PR let me know and I'll open a separate issue to discuss it 🙂 