### PR TITLE
docs:fix typesetting rendering

### DIFF
--- a/pyroomacoustics/bss/common.py
+++ b/pyroomacoustics/bss/common.py
@@ -44,13 +44,13 @@ def projection_back(Y, ref, clip_up=None, clip_down=None):
 
     .. math::
 
-        0 & = E[y^*\\, (z^* y - x)]
+        0 & = E[y^*\, (z^* y - x)]
 
-        0 & = z^*\\, E[|y|^2] - E[y^* x]
+        0 & = z^*\, E[|y|^2] - E[y^* x]
 
-        z^* & = \\frac{E[y^* x]}{E[|y|^2]}
+        z^* & = \frac{E[y^* x]}{E[|y|^2]}
 
-        z & = \\frac{E[y x^*]}{E[|y|^2]}
+        z & = \frac{E[y x^*]}{E[|y|^2]}
 
     In practice, the expectations are replaced by the sample
     mean.

--- a/pyroomacoustics/denoise/iterative_wiener.py
+++ b/pyroomacoustics/denoise/iterative_wiener.py
@@ -43,7 +43,7 @@ class IterativeWiener(object):
 
     .. math::
 
-        H(\\omega) = \dfrac{P_S(\\omega)}{P_S(\\omega) + \\sigma_d^2},
+        H(\omega) = \dfrac{P_S(\omega)}{P_S(\omega) + \sigma_d^2},
 
 
     where :math:`P_S(\omega)` is the speech power spectral density and
@@ -84,12 +84,12 @@ class IterativeWiener(object):
 
     .. math::
 
-        \sigma_d^2[k] = \\alpha \cdot \sigma_d^2[k-1] + (1-\\alpha) \cdot \sigma_y^2,
+        \sigma_d^2[k] = \alpha \cdot \sigma_d^2[k-1] + (1-\alpha) \cdot \sigma_y^2,
 
-    where :math:`\\alpha` is the smoothing parameter and :math:`\sigma_y^2` is
-    the energy of the input frame. A high value of :math:`\\alpha` will update
+    where :math:`\alpha` is the smoothing parameter and :math:`\sigma_y^2` is
+    the energy of the input frame. A high value of :math:`\alpha` will update
     the noise level very slowly, while a low value will make it very sensitive
-    to changes at the input. The value for :math:`\\alpha` can be set with the
+    to changes at the input. The value for :math:`\alpha` can be set with the
     `alpha` parameter.
 
     **When speech is identified in the input frame**, an iterative procedure is
@@ -257,7 +257,7 @@ def compute_speech_psd(a, g2, nfft):
 
     .. math::
 
-        P_S(\\omega) = \dfrac{g^2}{\\left \| 1 - \sum_{k=1}^p a_k \cdot e^{-jk\omega} \\right \|^2},
+        P_S(\omega) = \dfrac{g^2}{\left \| 1 - \sum_{k=1}^p a_k \cdot e^{-jk\omega} \right \|^2},
 
     where :math:`p` is the LPC order, :math:`a_k` are the LPC coefficients, and
     :math:`g` is an estimated gain factor.
@@ -297,7 +297,7 @@ def compute_squared_gain(a, noise_psd, y):
 
     .. math::
 
-        \dfrac{N}{2\pi} \int_{-\pi}^{\pi} \dfrac{g^2}{\\left \| 1 - \sum_{k=1}^p a_k \cdot e^{-jk\omega} \\right \|^2} d\omega = \sum_{n=0}^{N-1} y^2(n) - N\cdot\sigma_d^2,
+        \dfrac{N}{2\pi} \int_{-\pi}^{\pi} \dfrac{g^2}{\left \| 1 - \sum_{k=1}^p a_k \cdot e^{-jk\omega} \right \|^2} d\omega = \sum_{n=0}^{N-1} y^2(n) - N\cdot\sigma_d^2,
 
 
     where :math:`N` is the number of noisy samples :math:`y`, :math:`a_k`

--- a/pyroomacoustics/denoise/spectral_subtraction.py
+++ b/pyroomacoustics/denoise/spectral_subtraction.py
@@ -37,7 +37,7 @@ class SpectralSub(object):
 
     .. math::
 
-        G[k, n] = \max \\left \{ \\left ( \dfrac{P[k, n]-\\beta P_N[k, n]}{P[k, n]} \\right )^\\alpha, G_{min} \\right \},
+        G[k, n] = \max \left \{ \left ( \dfrac{P[k, n]-\beta P_N[k, n]}{P[k, n]} \right )^\alpha, G_{min} \right \},
 
     where :math:`G_{min} = 10^{-(db\_reduc/20)}` and :math:`db\_reduc` is the
     maximum reduction (in dB) that we are willing to perform for each bin (a
@@ -64,7 +64,7 @@ class SpectralSub(object):
     `Here <https://www.vocal.com/noise-reduction/musical-noise/>`_ is nice
     article about noise reduction and musical noise.
 
-    Adjusting the constants :math:`\\beta` and :math:`\\alpha` also presents a
+    Adjusting the constants :math:`\beta` and :math:`\alpha` also presents a
     trade-off between suppression and undesirable artefacts, i.e. more
     noticeable musical noise.
 


### PR DESCRIPTION
- [x] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
~~- [ ] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?_~~
~~- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is ~~covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
~~- [ ] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.~~
~~- [ ] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".~~

Hello,

I needed some of your docs for my own work and noticed that some parts weren't rendering correctly. I've just made some minor changes for the errant double escaping of TeX strings. I can update the CHANGELOG if needs be but I suspect it's not necessary for something like this.

All the best,
Michael
