### PR TITLE
updated in `doa.py`, the `ax.xaxis.grid` and `ax.yaxis.grid` parameters were changed from `b` to `visible`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,9 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 
 `Unreleased`_
 -------------
-
-Nothing yet
+Bugfix:
+~~~~~~
+in `doa.py`, the `ax.xaxis.grid` and `ax.yaxis.grid` parameters were changed from `b` to `visible`.
 
 `0.8.4`_ - 2025-05-19
 ---------------------

--- a/pyroomacoustics/doa/doa.py
+++ b/pyroomacoustics/doa/doa.py
@@ -557,8 +557,8 @@ class DOA(object):
         ax.set_xticks(np.linspace(0, 2 * np.pi, num=12, endpoint=False))
         ax.xaxis.set_label_coords(0.5, -0.11)
         ax.set_yticks(np.linspace(0, 1, 2))
-        ax.xaxis.grid(b=True, color=[0.3, 0.3, 0.3], linestyle=":")
-        ax.yaxis.grid(b=True, color=[0.3, 0.3, 0.3], linestyle="--")
+        ax.xaxis.grid(visible=True, color=[0.3, 0.3, 0.3], linestyle=":")
+        ax.yaxis.grid(visible=True, color=[0.3, 0.3, 0.3], linestyle="--")
         ax.set_ylim([0, 1.05 * (base + height)])
 
         plt.tight_layout()


### PR DESCRIPTION
Thanks for sending a pull request (PR), we really appreciate that! Before hitting the submit button, we'd be really glad if you could make sure all the following points have been cleared.

Please also refer to the doc on [contributing](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html) for more details. Even if you can't check all the boxes below, do not hesitate to go ahead with the PR and ask for help there.

- [ ] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [ ] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [ ] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [ ] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [1 ] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:



grid_b keyword is deprecated.
