### PR TITLE
MicrophoneArray.append(MicrophoneArray), do not crash when signal exists

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,11 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
-Nothing yet
+Bugfix
+~~~~~~
+
+- Fixes MicrophoneArray.append(MicrophoneArray)
+  AttributeError: 'MicrophoneArray' object has no attribute 'shape'.
 
 `0.8.4`_ - 2025-05-19
 ---------------------

--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -535,12 +535,15 @@ class MicrophoneArray(object):
             a `numpy.ndarray` with each column containing the coordinates of a
             microphone.
         """
+        n_new_mics = 0
         if isinstance(locs, MicrophoneArray):
             self.R = np.concatenate((self.R, locs.R), axis=1)
             self.directivity += locs.directivity
+            n_new_mics = locs.R.shape[1]
         else:
             self.R = np.concatenate((self.R, locs), axis=1)
             self.directivity += [None] * locs.shape[1]
+            n_new_mics = locs.shape[1]
 
         # in case there was already some signal recorded, just pad with zeros
         if self.signals is not None:
@@ -548,7 +551,7 @@ class MicrophoneArray(object):
                 (
                     self.signals,
                     np.zeros(
-                        (locs.shape[1], self.signals.shape[1]), dtype=self.signals.dtype
+                        (n_new_mics, self.signals.shape[1]), dtype=self.signals.dtype
                     ),
                 ),
                 axis=0,

--- a/pyroomacoustics/tests/test_microphone_array.py
+++ b/pyroomacoustics/tests/test_microphone_array.py
@@ -99,3 +99,11 @@ def test_microphone_array_append(shape1, shape2, with_dir, from_raw_locs):
 
     assert mic_array.nmic == shape1[1] + shape2[1]
     assert len(mic_array.directivity) == shape1[1] + shape2[1]
+
+
+def test_microphone_array_append_with_existing_signals():
+    mic_array = pra.MicrophoneArray(np.ones((3, 2)), fs=_FS)
+    mic_array.signals = np.random.randn(2, 1000)
+    new_mic_array = pra.MicrophoneArray(np.ones((3, 1)), fs=_FS)
+    mic_array.append(new_mic_array)
+    assert mic_array.nmic == 3


### PR DESCRIPTION
Thanks for sending a pull request (PR), we really appreciate that! Before hitting the submit button, we'd be really glad if you could make sure all the following points have been cleared.

Please also refer to the doc on [contributing](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html) for more details. Even if you can't check all the boxes below, do not hesitate to go ahead with the PR and ask for help there.

- [x] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [x] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [x] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [x] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [x] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".

Happy PR :smiley:


hey, thank you for pyroomacoutics!

this pull request fixes a small issue i bumped into when trying to use it in my toy example, when i have few microphones and they are added sequentionally at different points in time with the following stacktrace:

```
2025-07-21 11:47:12,185 - simulator.virtual_speaker - ERROR - Error processing audio chunk: 'MicrophoneArray' object has no attribute 'shape'
2025-07-21 11:47:12,185 - simulator.virtual_speaker - ERROR - Full traceback: Traceback (most recent call last):
  File "/.../simulator/virtual_speaker.py", line 117, in _process_audio_chunk
    await self.speaker_server.room_sim.update_simulation()
  File "/.../simulator/room_simulation.py", line 145, in update_simulation
    self.room.add_microphone_array(mic_positions.T)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/.../simulator/venv/lib/python3.13/site-packages/pyroomacoustics/room.py", line 2115, in add_microphone_array
    return self.add(mic_array)
           ~~~~~~~~^^^^^^^^^^^
  File "/.../simulator/venv/lib/python3.13/site-packages/pyroomacoustics/room.py", line 2018, in add
    self.mic_array.append(obj)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/.../simulator/venv/lib/python3.13/site-packages/pyroomacoustics/beamforming.py", line 551, in append
    (locs.shape[1], self.signals.shape[1]), dtype=self.signals.dtype
     ^^^^^^^^^^
AttributeError: 'MicrophoneArray' object has no attribute 'shape'
```

 I have not nailed the example yet, maybe the my usage is borked and i should not want to do this, but this still seems like a correct fix.

pyright seems to find this too.
<img width="2436" height="1756" alt="Screenshot 2025-07-21 at 21 55 27" src="https://github.com/user-attachments/assets/6fc8971a-963e-458d-ad87-2e7389b1864d" />

added a test which does fail before and passes after.

thank you again!