### PR TITLE
fix: clamp RT histogram to non-negative before sqrt

### DIFF
--- a/pyroomacoustics/simulation/rt.py
+++ b/pyroomacoustics/simulation/rt.py
@@ -280,7 +280,11 @@ def compute_rt_rir(
         hist = interp_hist(hist_bands[b, :], N)
 
         # Impulse response for every octave band for each microphone.
-        rir_bands[b, :] = seq_bp * np.sqrt(hist)
+        # Clamp to non-negative: interp_hist can produce tiny negatives
+        # from floating-point noise in linear interpolation.  sqrt of a
+        # negative yields NaN which downstream IIR filters (e.g. the
+        # high-pass in compute_rir) then propagate to the entire RIR.
+        rir_bands[b, :] = seq_bp * np.sqrt(np.maximum(hist, 0.0))
 
     if air_abs_coeffs is not None:
         if rir_bands.shape[0] == 1:


### PR DESCRIPTION
## Summary

- `interp_hist()` can produce tiny negative values (~1e-31) from floating-point noise in linear interpolation of energy histograms
- `np.sqrt()` turns these into NaN
- Downstream IIR filters (`sosfiltfilt` in `compute_rir`'s high-pass) propagate a single NaN sample to the **entire** RIR, silently destroying it
- Fix: `np.sqrt(np.maximum(hist, 0.0))` — clamp before sqrt

Fixes #433.

## Reproduction

The issue triggers when ray tracing + HRTF directivity are combined. A specific source/mic geometry produces a histogram band where linear interpolation dips infinitesimally below zero. The resulting NaN cascades through the IIR high-pass filter to corrupt every sample in the RIR.

## Test plan

- [x] Verified fix eliminates NaN in reproduction case from #433
- [x] Verified fix eliminates NaN in our production workload (14-source binaural room render with KU100 HRTF)
- [x] L/R balance corrected from +8 dB bias to -0.07 dB after fix