### PR TITLE
spiral_2D_array now uses the center parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,10 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
-Nothing yet.
+Fixed
+~~~~~
+
+- `spiral_2D_array` now correctly uses the ``center`` parameter. Previously, it always returned the array at the origin. (`#413 <https://github.com/LCAV/pyroomacoustics/issues/413>`_).
 
 
 `0.10.1`_ - 2026-05-01

--- a/pyroomacoustics/beamforming.py
+++ b/pyroomacoustics/beamforming.py
@@ -242,7 +242,7 @@ def spiral_2D_array(center, M, radius=1.0, divi=3, angle=None):
     pos_mic_x = pos_array_norm * np.cos(pos_array_angle)
     pos_mic_y = pos_array_norm * np.sin(pos_array_angle)
 
-    return np.array([pos_mic_x, pos_mic_y])
+    return np.array(center)[:, np.newaxis] + np.array([pos_mic_x, pos_mic_y])
 
 
 def fir_approximation_ls(weights, T, n1, n2):

--- a/tests/test_issue_413.py
+++ b/tests/test_issue_413.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+import pyroomacoustics as pra
+
+
+def test_spiral_2d_array_center():
+    """Test that spiral_2D_array correctly uses the center parameter."""
+
+    # Test with fixed angle to avoid random variance
+    angle = 0.3
+
+    # Array at origin
+    arr0 = pra.spiral_2D_array([0, 0], 10, radius=1.0, divi=3, angle=angle)
+
+    # Same array shifted
+    center = np.array([2.5, -1.5])
+    arr_shifted = pra.spiral_2D_array(center, 10, radius=1.0, divi=3, angle=angle)
+
+    # Every point should be shifted by exactly the center offset
+    np.testing.assert_allclose(arr_shifted[0] - arr0[0], center[0])
+    np.testing.assert_allclose(arr_shifted[1] - arr0[1], center[1])
+
+    # Test single point (M=1) — should be at center
+    arr_single = pra.spiral_2D_array([5.0, -3.0], 1, radius=2.0, angle=0.0)
+    np.testing.assert_allclose(arr_single.ravel(), [5.0, -3.0])
+
+    # Test that center as list also works
+    arr_list = pra.spiral_2D_array([1.0, 2.0], 4, radius=0.5, divi=2, angle=0.0)
+    assert arr_list.shape == (2, 4)


### PR DESCRIPTION
The `spiral_2D_array` function accepted a `center` parameter but didn't use it — the array was always returned at the origin. All other array generators (`linear_2D_array`, `circular_2D_array`, `poisson_2D_array`) add the center offset correctly, so this brings the spiral function in line.

Fixes #413.

- [X] Are there docstrings ? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style ?
- [X] Have you run the tests by doing `nosetests` or `py.test` at the root of the repo ?
- [X] Have you checked that the doc builds properly and that any new file has been added to the repo ? How to do that is covered in the [documentation](https://pyroomacoustics.readthedocs.io/en/pypi-release/contributing.html#documentation).
- [X] Is there a unit test for the proposed code modification ? If the PR addresses an issue, the test should make sure the issue is fixed.
- [X] Last but not least, did you document the proposed change in the CHANGELOG file ? It should go under "Unreleased".
