### PR TITLE
Fix to_float32 producing nan/inf for unsigned-integer (8-bit WAV) input

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 ~~~~~
 
 - `spiral_2D_array` now correctly uses the ``center`` parameter. Previously, it always returned the array at the origin. (`#413 <https://github.com/LCAV/pyroomacoustics/issues/413>`_).
+- ``to_float32`` no longer produces ``nan``/``inf`` for unsigned-integer input (e.g. 8-bit WAV read as ``uint8``). Unsigned PCM is now centered and scaled correctly instead of dividing by zero.
 
 
 `0.10.1`_ - 2026-05-01

--- a/pyroomacoustics/utilities.py
+++ b/pyroomacoustics/utilities.py
@@ -181,7 +181,13 @@ def to_float32(data):
         `data` as float32.
     """
 
-    if np.issubdtype(data.dtype, np.integer):
+    if np.issubdtype(data.dtype, np.unsignedinteger):
+        # Unsigned PCM (e.g. 8-bit WAV) is centered at 2 ** (bits - 1), not 0.
+        # ``np.iinfo(dtype).min`` is 0 here, so scaling by it would divide by
+        # zero and produce nan/inf.
+        midpoint = 2 ** (8 * data.dtype.itemsize - 1)
+        return (data.astype(np.float32) - midpoint) / midpoint
+    elif np.issubdtype(data.dtype, np.integer):
         max_val = abs(np.iinfo(data.dtype).min)
         return data.astype(np.float32) / max_val
     else:

--- a/tests/test_to_float32.py
+++ b/tests/test_to_float32.py
@@ -1,0 +1,86 @@
+"""
+Tests for ``pyroomacoustics.utilities.to_float32``.
+
+Unsigned integer PCM (e.g. 8-bit WAV files, which ``scipy.io.wavfile.read``
+returns as ``uint8``) has ``np.iinfo(dtype).min == 0``.  The old
+implementation computed ``max_val = abs(np.iinfo(dtype).min) == 0`` and
+divided by it, silently producing ``nan``/``inf`` and corrupting the signal.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+from scipy.io import wavfile
+
+from pyroomacoustics import create_noisy_signal
+from pyroomacoustics.utilities import to_float32
+
+
+def test_uint8_is_finite_and_in_range():
+    # Full uint8 range; libsndfile/soundfile map 8-bit unsigned PCM to
+    # [-1, 1) via (x - 128) / 128.
+    data = np.arange(256, dtype=np.uint8)
+    out = to_float32(data)
+
+    assert out.dtype == np.float32
+    assert np.all(np.isfinite(out)), "8-bit unsigned WAV data produced nan/inf"
+    assert out.min() >= -1.0
+    assert out.max() < 1.0
+
+    expected = (data.astype(np.float32) - 128.0) / 128.0
+    np.testing.assert_allclose(out, expected, rtol=0, atol=0)
+    # Midpoint of the unsigned range maps to silence (0.0).
+    assert to_float32(np.array([128], dtype=np.uint8))[0] == 0.0
+
+
+def test_uint16_is_finite_and_in_range():
+    data = np.array([0, 32768, 65535], dtype=np.uint16)
+    out = to_float32(data)
+
+    assert np.all(np.isfinite(out))
+    expected = (data.astype(np.float32) - 32768.0) / 32768.0
+    np.testing.assert_allclose(out, expected, rtol=0, atol=0)
+
+
+def test_int16_unchanged():
+    # Signed integer behaviour must be preserved: min -> -1.0, max -> ~1.0.
+    data = np.array([-32768, 0, 32767], dtype=np.int16)
+    out = to_float32(data)
+    np.testing.assert_allclose(out, [-1.0, 0.0, 32767.0 / 32768.0], atol=1e-7)
+
+
+def test_float_passthrough():
+    data = np.array([-0.5, 0.0, 0.5], dtype=np.float64)
+    out = to_float32(data)
+    assert out.dtype == np.float32
+    np.testing.assert_allclose(out, data, atol=1e-7)
+
+
+def test_create_noisy_signal_with_8bit_wav():
+    # End-to-end: an 8-bit WAV read by scipy is uint8 and must not corrupt
+    # the loaded signal.
+    fs = 16000
+    t = np.arange(fs) / fs
+    tone = 0.5 * np.sin(2 * np.pi * 220 * t)
+    pcm_u8 = np.round(tone * 127 + 128).astype(np.uint8)
+
+    with tempfile.TemporaryDirectory() as d:
+        fp = os.path.join(d, "tone_u8.wav")
+        wavfile.write(fp, fs, pcm_u8)
+        assert wavfile.read(fp)[1].dtype == np.uint8  # 8-bit WAV -> uint8
+
+        noisy, clean, noise, fs_out = create_noisy_signal(fp, snr=10)
+
+    assert np.all(np.isfinite(clean)), "8-bit WAV corrupted the clean signal"
+    assert np.all(np.isfinite(noisy))
+    assert fs_out == fs
+
+
+if __name__ == "__main__":
+    test_uint8_is_finite_and_in_range()
+    test_uint16_is_finite_and_in_range()
+    test_int16_unchanged()
+    test_float_passthrough()
+    test_create_noisy_signal_with_8bit_wav()
+    print("ok")


### PR DESCRIPTION
### Problem

`to_float32` turns unsigned-integer input into `nan`/`inf`:

```python
import numpy as np
from pyroomacoustics.utilities import to_float32

to_float32(np.array([0, 128, 255], dtype=np.uint8))
# RuntimeWarning: divide by zero
# array([nan, inf, inf], dtype=float32)
```

It scales integer input by `abs(np.iinfo(dtype).min)`. For **unsigned** integer
dtypes that minimum is `0`, so the division is by zero.

This is hit in practice by **8-bit WAV files**: `scipy.io.wavfile.read` returns
them as `uint8`, and they flow through `create_noisy_signal` → `to_float32`
(whose docstring notes the input is "typically obtained from a WAV file"),
silently turning the whole signal into `nan`/`inf`.

### Fix

Handle unsigned integers separately. Unsigned PCM is centered at `2**(bits-1)`,
so map it with `(data - midpoint) / midpoint` — matching the
libsndfile/soundfile `PCM_U8` convention and consistent with the existing
signed-integer scaling (`data / 2**(bits-1)`). Signed-integer and float inputs
are unchanged:

```python
>>> to_float32(np.array([0, 128, 255], dtype=np.uint8))
array([-1.        ,  0.        ,  0.9921875], dtype=float32)
```

### Tests

`tests/test_to_float32.py`: `uint8` full-range finiteness + exact `(x-128)/128`
values + midpoint→0.0; `uint16` range; an `int16` regression guard (output
unchanged); float passthrough; and an end-to-end `create_noisy_signal` on a
generated 8-bit WAV asserting finite output.

RED→GREEN: 3 of the 5 new tests fail on the current code (uint8, uint16,
end-to-end produce nan/inf); all 5 pass with the fix. Relevant suites
(`test_to_float32`, `test_metrics`, `test_hpf`, `test_resample`,
`test_bandpass_filterbank`) → 16 passed, no regressions. `ruff check` clean on
the changed lines.
